### PR TITLE
Retrying to get the file cache if it is undefined

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -40,19 +40,74 @@ export const replaceTaskWithTasks = async ({
         newTasks = [newTasks];
     }
 
+    tryRepetitive({
+        originalTask,
+        newTasks,
+        vault,
+        metadataCache,
+        previousTries: 0,
+    });
+};
+
+/**
+ * This is a workaround to re-try when the returned file cache is `undefined`.
+ * Retrying after a while may return a valid file cache.
+ * Reported in https://github.com/schemar/obsidian-tasks/issues/87
+ */
+const tryRepetitive = async ({
+    originalTask,
+    newTasks,
+    vault,
+    metadataCache,
+    previousTries,
+}: {
+    originalTask: Task;
+    newTasks: Task[];
+    vault: Vault;
+    metadataCache: MetadataCache;
+    previousTries: number;
+}): Promise<void> => {
+    const retry = () => {
+        if (previousTries > 10) {
+            console.error(
+                'Tasks: Too many retries. File update not possible ...',
+            );
+        }
+
+        const timeout = Math.min(Math.pow(10, previousTries), 100); // 1, 10, 100, 100, 100, ...
+        setTimeout(() => {
+            tryRepetitive({
+                originalTask,
+                newTasks,
+                vault,
+                metadataCache,
+                previousTries: previousTries + 1,
+            });
+        }, timeout);
+    };
+
     const file = vault.getAbstractFileByPath(originalTask.path);
     if (!(file instanceof TFile)) {
-        return;
+        console.warn(
+            `Tasks: No file found for task ${originalTask.description}. Retrying ...`,
+        );
+        return retry();
     }
 
     const fileCache = metadataCache.getFileCache(file);
-    if (fileCache === null) {
-        return;
+    if (fileCache == undefined || fileCache === null) {
+        console.warn(
+            `Tasks: No file cache found for file ${file.path}. Retrying ...`,
+        );
+        return retry();
     }
 
     const listItemsCache = fileCache.listItems;
     if (listItemsCache === undefined || listItemsCache.length === 0) {
-        return;
+        console.warn(
+            `Tasks: No list items found in file cache of ${file.path}. Retrying ...`,
+        );
+        return retry();
     }
 
     const fileContent = await vault.cachedRead(file);
@@ -82,6 +137,7 @@ export const replaceTaskWithTasks = async ({
         }
     }
     if (listItem === undefined) {
+        console.error('Tasks: could not find task to toggle in the file.');
         return;
     }
 


### PR DESCRIPTION
The file cache that the metadata cache returns can be undefined. We
retry to see if it is set at a later stage. Retrying fixes a reported
bug.

See https://github.com/schemar/obsidian-tasks/issues/87 for details.

Fixes #87