### PR TITLE
Added support for "task" at the end of command palette options

### DIFF
--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -15,7 +15,7 @@ export class Commands {
 
         plugin.addCommand({
             id: 'edit-task',
-            name: 'Create or edit',
+            name: 'Create or edit task',
             editorCheckCallback: (
                 checking: boolean,
                 editor: Editor,
@@ -27,7 +27,7 @@ export class Commands {
 
         plugin.addCommand({
             id: 'toggle-done',
-            name: 'Toggle Done',
+            name: 'Toggle task done',
             editorCheckCallback: toggleDone,
         });
     }


### PR DESCRIPTION
Command palette options now appear when "task" at the end of the command search, ie:

- "Create task"
- "toggle task"

Per #185 