### PR TITLE
Added layout options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ main.js
 
 # obsidian
 data.json
+
+# osx
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Instead you would have two queries, one for each condition:
     ```
 
 #### Layout options
-You can hide certain elements of rendered list with the "hide" option.
+You can hide certain elements of the rendered list with the "hide" option.
 
 The following options exist:
 
@@ -262,6 +262,8 @@ The following options exist:
 - `due date`
 - `recurrence rule`
 - `task count`
+
+Example:
 
     ```tasks
     no due date

--- a/README.md
+++ b/README.md
@@ -251,6 +251,26 @@ Instead you would have two queries, one for each condition:
     path includes GitHub
     ```
 
+#### Layout options
+You can hide certain elements of rendered list with the "hide" option.
+
+The following options exist:
+
+- `edit button`
+- `backlink`
+- `done date`
+- `due date`
+- `recurrence rule`
+- `task count`
+
+    ```tasks
+    no due date
+    path includes GitHub
+    hide recurrence rule
+    hide task count
+    hide backlink
+    ```
+
 #### Examples
 
 All open tasks that are due today:
@@ -283,12 +303,14 @@ Show all tasks that aren't done, are due on the 9th of April 2021, and where the
     path includes GitHub
     ````
 
-Show all open tasks that are due within two weeks:
+Show all open tasks that are due within two weeks and hide the due date and edit button:
 
     ```tasks
     not done
     due after 2021-04-30
     due before 2021-05-15
+    hide due date
+    hide edit button
     ```
 
 Show all tasks that were done before the 1st of December 2020:

--- a/src/LayoutOptions.ts
+++ b/src/LayoutOptions.ts
@@ -1,0 +1,8 @@
+export class LayoutOptions {
+    hideTaskCount: boolean = false
+    hideBacklinks: boolean = false
+    hideDoneDate: boolean = false
+    hideDueDate: boolean = false
+    hideRecurrenceRule: boolean = false
+    hideEditButton: boolean = false
+}

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -94,7 +94,7 @@ export class Query {
 
         const hideOptionsMatch = line.match(this.hideOptionsRegexp);
         if (hideOptionsMatch !== null) {
-            var option = hideOptionsMatch[1].trim().toLowerCase()
+            let option = hideOptionsMatch[1].trim().toLowerCase()
 
             if (option === 'task count') {
                 this._layoutOptions.hideTaskCount = true;

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -10,10 +10,10 @@ export class Query {
     private _error: string | undefined = undefined;
 
     private readonly noDueString = 'no due date';
-    private readonly dueRegexp = /due (before|after|on)? ?(.*)/;
+    private readonly dueRegexp = /due (before|after|on) ?(.*)/;
     private readonly doneString = 'done';
     private readonly notDoneString = 'not done';
-    private readonly doneRegexp = /done (before|after|on)? ?(.*)/;
+    private readonly doneRegexp = /done (before|after|on) ?(.*)/;
     private readonly pathRegexp = /path (includes|does not include) (.*)/;
     private readonly descriptionRegexp =
         /description (includes|does not include) (.*)/;

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -4,6 +4,8 @@ import { Status, Task } from './Task';
 
 export class Query {
     private _limit: number | undefined = undefined;
+    private _showTaskCount: boolean = true;
+    private _showBacklinks: boolean = true;
     private _filters: ((task: Task) => boolean)[] = [];
     private _error: string | undefined = undefined;
 
@@ -16,6 +18,7 @@ export class Query {
     private readonly descriptionRegexp =
         /description (includes|does not include) (.*)/;
     private readonly headingRegexp = /heading (includes|does not include) (.*)/;
+    private readonly layoutRegexp = /(layoutOptions): (.*)/
     private readonly limitRegexp = /limit (to )?(\d+)( tasks?)?/;
     private readonly excludeSubItemsString = 'exclude sub-items';
 
@@ -61,6 +64,9 @@ export class Query {
                     case this.limitRegexp.test(line):
                         this.parseLimit({ line });
                         break;
+                    case this.layoutRegexp.test(line):
+                        this.parseLayout({ line });
+                        break;
                     default:
                         this._error = 'do not understand query';
                 }
@@ -71,12 +77,39 @@ export class Query {
         return this._limit;
     }
 
+    public get showTaskCount(): boolean {
+        return this._showTaskCount;
+    }
+
+    public get showBacklinks(): boolean {
+        return this._showBacklinks;
+    }
+
     public get filters(): ((task: Task) => boolean)[] {
         return this._filters;
     }
 
     public get error(): string | undefined {
         return this._error;
+    }
+
+    private parseLayout({ line }: { line: string }): void {
+        const layoutOptionMatch = line.match(this.layoutRegexp);
+        if (layoutOptionMatch !== null) {
+            var splittedOptions = layoutOptionMatch[2].split(",");
+
+            splittedOptions.forEach(s => {
+                var option = s.trim().toLowerCase()
+
+                if (option === 'hidetaskcount') {
+                    this._showTaskCount = false;
+                } else if (option === 'hidebacklinks') {
+                    this._showBacklinks = false;
+                } else {
+                    this._error = 'do not understand layout option';
+                }
+            });
+        }
     }
 
     private parseDueFilter({ line }: { line: string }): void {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -10,17 +10,17 @@ export class Query {
     private _error: string | undefined = undefined;
 
     private readonly noDueString = 'no due date';
-    private readonly dueRegexp = /due (before|after|on) ?(.*)/;
+    private readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
     private readonly doneString = 'done';
     private readonly notDoneString = 'not done';
-    private readonly doneRegexp = /done (before|after|on) ?(.*)/;
-    private readonly pathRegexp = /path (includes|does not include) (.*)/;
+    private readonly doneRegexp = /^done (before|after|on)? ?(.*)/;
+    private readonly pathRegexp = /^path (includes|does not include) (.*)/;
     private readonly descriptionRegexp =
-        /description (includes|does not include) (.*)/;
-    private readonly headingRegexp = /heading (includes|does not include) (.*)/;
+        /^description (includes|does not include) (.*)/;
+    private readonly headingRegexp = /^heading (includes|does not include) (.*)/;
     private readonly hideOptionsRegexp =
-        /hide (task count|backlink|done date|due date|recurrence rule|edit button)/
-    private readonly limitRegexp = /limit (to )?(\d+)( tasks?)?/;
+        /^hide (task count|backlink|done date|due date|recurrence rule|edit button)/
+    private readonly limitRegexp = /^limit (to )?(\d+)( tasks?)?/;
     private readonly excludeSubItemsString = 'exclude sub-items';
 
     constructor({ source }: { source: string }) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -177,64 +177,70 @@ class QueryRenderChild extends MarkdownRenderChild {
 
             const postInfo = listItem.createSpan();
 
-            if (!this.query.layoutOptions.hideBacklinks) {
-                if (fileName !== undefined) {
-                    postInfo.append(' (');
-                    const link = postInfo.createEl('a');
-                    link.href = fileName;
-                    link.setAttribute('data-href', fileName);
-                    link.rel = 'noopener';
-                    link.target = '_blank';
-                    link.addClass('internal-link');
-
-                    let linkText = fileName;
-                    if (task.precedingHeader !== null) {
-                        link.href = link.href + '#' + task.precedingHeader;
-                        link.setAttribute(
-                            'data-href',
-                            link.getAttribute('data-href') +
-                            '#' +
-                            task.precedingHeader,
-                        );
-
-                        // Otherwise, this wouldn't provide additinoal information and only take up space.
-                        if (task.precedingHeader !== fileName) {
-                            linkText = linkText + ' > ' + task.precedingHeader;
-                        }
-                    }
-
-                    link.setText(linkText);
-                    postInfo.append(')');
-                }
+            if (!this.query.layoutOptions.hideBacklinks && fileName !== undefined) {
+                this.addBacklinks(postInfo, fileName, task);
             }
 
             if (!this.query.layoutOptions.hideEditButton) {
-                const editTaskPencil = postInfo.createEl('a', {
-                    cls: 'tasks-edit',
-                });
-                editTaskPencil.onClickEvent((event: MouseEvent) => {
-                    event.preventDefault();
-
-                    const onSubmit = (updatedTasks: Task[]): void => {
-                        replaceTaskWithTasks({
-                            originalTask: task,
-                            newTasks: updatedTasks,
-                        });
-                    };
-
-                    // Need to create a new instance every time, as cursor/task can change.
-                    const taskModal = new TaskModal({
-                        app: this.app,
-                        task,
-                        onSubmit,
-                    });
-                    taskModal.open();
-                });
+                this.addEditButton(postInfo, task);
             }
 
             taskList.appendChild(listItem);
         }
 
         return { taskList, tasksCount };
+    }
+
+    private addEditButton(postInfo: HTMLSpanElement, task: Task) {
+        const editTaskPencil = postInfo.createEl('a', {
+            cls: 'tasks-edit',
+        });
+        editTaskPencil.onClickEvent((event: MouseEvent) => {
+            event.preventDefault();
+
+            const onSubmit = (updatedTasks: Task[]): void => {
+                replaceTaskWithTasks({
+                    originalTask: task,
+                    newTasks: updatedTasks,
+                });
+            };
+
+            // Need to create a new instance every time, as cursor/task can change.
+            const taskModal = new TaskModal({
+                app: this.app,
+                task,
+                onSubmit,
+            });
+            taskModal.open();
+        });
+    }
+
+    private addBacklinks(postInfo: HTMLSpanElement, fileName: string, task: Task) {
+        postInfo.append(' (');
+        const link = postInfo.createEl('a');
+        link.href = fileName;
+        link.setAttribute('data-href', fileName);
+        link.rel = 'noopener';
+        link.target = '_blank';
+        link.addClass('internal-link');
+
+        let linkText = fileName;
+        if (task.precedingHeader !== null) {
+            link.href = link.href + '#' + task.precedingHeader;
+            link.setAttribute(
+                'data-href',
+                link.getAttribute('data-href') +
+                '#' +
+                task.precedingHeader
+            );
+
+            // Otherwise, this wouldn't provide additinoal information and only take up space.
+            if (task.precedingHeader !== fileName) {
+                linkText = linkText + ' > ' + task.precedingHeader;
+            }
+        }
+
+        link.setText(linkText);
+        postInfo.append(')');
     }
 }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -123,7 +123,7 @@ class QueryRenderChild extends MarkdownRenderChild {
                 content,
             });
             content.appendChild(taskList);
-            if (this.query.showTaskCount) {
+            if (!this.query.layoutOptions.hideTaskCount) {
                 content.createDiv({
                     text: `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`,
                     cls: 'tasks-count',
@@ -172,11 +172,12 @@ class QueryRenderChild extends MarkdownRenderChild {
             const listItem = await task.toLi({
                 parentUlElement: taskList,
                 listIndex: i,
+                layoutOptions: this.query.layoutOptions
             });
 
             const postInfo = listItem.createSpan();
 
-            if (this.query.showBacklinks) {
+            if (!this.query.layoutOptions.hideBacklinks) {
                 if (fileName !== undefined) {
                     postInfo.append(' (');
                     const link = postInfo.createEl('a');
@@ -207,27 +208,29 @@ class QueryRenderChild extends MarkdownRenderChild {
                 }
             }
 
-            const editTaskPencil = postInfo.createEl('a', {
-                cls: 'tasks-edit',
-            });
-            editTaskPencil.onClickEvent((event: MouseEvent) => {
-                event.preventDefault();
-
-                const onSubmit = (updatedTasks: Task[]): void => {
-                    replaceTaskWithTasks({
-                        originalTask: task,
-                        newTasks: updatedTasks,
-                    });
-                };
-
-                // Need to create a new instance every time, as cursor/task can change.
-                const taskModal = new TaskModal({
-                    app: this.app,
-                    task,
-                    onSubmit,
+            if (!this.query.layoutOptions.hideEditButton) {
+                const editTaskPencil = postInfo.createEl('a', {
+                    cls: 'tasks-edit',
                 });
-                taskModal.open();
-            });
+                editTaskPencil.onClickEvent((event: MouseEvent) => {
+                    event.preventDefault();
+
+                    const onSubmit = (updatedTasks: Task[]): void => {
+                        replaceTaskWithTasks({
+                            originalTask: task,
+                            newTasks: updatedTasks,
+                        });
+                    };
+
+                    // Need to create a new instance every time, as cursor/task can change.
+                    const taskModal = new TaskModal({
+                        app: this.app,
+                        task,
+                        onSubmit,
+                    });
+                    taskModal.open();
+                });
+            }
 
             taskList.appendChild(listItem);
         }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -123,10 +123,12 @@ class QueryRenderChild extends MarkdownRenderChild {
                 content,
             });
             content.appendChild(taskList);
-            content.createDiv({
-                text: `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`,
-                cls: 'tasks-count',
-            });
+            if (this.query.showTaskCount) {
+                content.createDiv({
+                    text: `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`,
+                    cls: 'tasks-count',
+                });
+            }
         } else if (this.query.error !== undefined) {
             content.setText(`Tasks query: ${this.query.error}`);
         } else {
@@ -173,33 +175,36 @@ class QueryRenderChild extends MarkdownRenderChild {
             });
 
             const postInfo = listItem.createSpan();
-            if (fileName !== undefined) {
-                postInfo.append(' (');
-                const link = postInfo.createEl('a');
-                link.href = fileName;
-                link.setAttribute('data-href', fileName);
-                link.rel = 'noopener';
-                link.target = '_blank';
-                link.addClass('internal-link');
 
-                let linkText = fileName;
-                if (task.precedingHeader !== null) {
-                    link.href = link.href + '#' + task.precedingHeader;
-                    link.setAttribute(
-                        'data-href',
-                        link.getAttribute('data-href') +
+            if (this.query.showBacklinks) {
+                if (fileName !== undefined) {
+                    postInfo.append(' (');
+                    const link = postInfo.createEl('a');
+                    link.href = fileName;
+                    link.setAttribute('data-href', fileName);
+                    link.rel = 'noopener';
+                    link.target = '_blank';
+                    link.addClass('internal-link');
+
+                    let linkText = fileName;
+                    if (task.precedingHeader !== null) {
+                        link.href = link.href + '#' + task.precedingHeader;
+                        link.setAttribute(
+                            'data-href',
+                            link.getAttribute('data-href') +
                             '#' +
                             task.precedingHeader,
-                    );
+                        );
 
-                    // Otherwise, this wouldn't provide additinoal information and only take up space.
-                    if (task.precedingHeader !== fileName) {
-                        linkText = linkText + ' > ' + task.precedingHeader;
+                        // Otherwise, this wouldn't provide additinoal information and only take up space.
+                        if (task.precedingHeader !== fileName) {
+                            linkText = linkText + ' > ' + task.precedingHeader;
+                        }
                     }
-                }
 
-                link.setText(linkText);
-                postInfo.append(')');
+                    link.setText(linkText);
+                    postInfo.append(')');
+                }
             }
 
             const editTaskPencil = postInfo.createEl('a', {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -4,7 +4,7 @@ import { RRule } from 'rrule';
 import { replaceTaskWithTasks } from './File';
 import { getSettings } from './Settings';
 import type { Moment } from 'moment';
-import type { LayoutOptions } from 'LayoutOptions';
+import { LayoutOptions } from 'LayoutOptions';
 
 export enum Status {
     Todo = 'Todo',
@@ -268,23 +268,24 @@ export class Task {
 
     public toString(layoutOptions?: LayoutOptions): string {
 
-        var taskString = this.description;
+        layoutOptions = layoutOptions ?? new LayoutOptions();
+        let taskString = this.description;
 
-        if (layoutOptions == undefined || !layoutOptions.hideRecurrenceRule) {
+        if (!layoutOptions.hideRecurrenceRule) {
             const recurrenceRule: string = this.recurrenceRule
                 ? ` 🔁 ${this.recurrenceRule.toText()}`
                 : '';
             taskString += recurrenceRule;
         }
 
-        if (layoutOptions == undefined || !layoutOptions.hideDueDate) {
+        if (!layoutOptions.hideDueDate) {
             const dueDate: string = this.dueDate
                 ? ` 📅 ${this.dueDate.format(Task.dateFormat)}`
                 : '';
             taskString += dueDate;
         }
 
-        if (layoutOptions == undefined || !layoutOptions.hideDoneDate) {
+        if (!layoutOptions.hideDoneDate) {
             const doneDate: string = this.doneDate
                 ? ` ✅ ${this.doneDate.format(Task.dateFormat)}`
                 : '';

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -4,7 +4,7 @@ import { RRule } from 'rrule';
 import { replaceTaskWithTasks } from './File';
 import { getSettings } from './Settings';
 import type { Moment } from 'moment';
-import { LayoutOptions } from 'LayoutOptions';
+import { LayoutOptions } from './LayoutOptions';
 
 export enum Status {
     Todo = 'Todo',

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -4,6 +4,7 @@ import { RRule } from 'rrule';
 import { replaceTaskWithTasks } from './File';
 import { getSettings } from './Settings';
 import type { Moment } from 'moment';
+import type { LayoutOptions } from 'LayoutOptions';
 
 export enum Status {
     Todo = 'Todo',
@@ -194,15 +195,17 @@ export class Task {
     public async toLi({
         parentUlElement,
         listIndex,
+        layoutOptions
     }: {
         parentUlElement: HTMLElement;
         /** The nth item in this list (including non-tasks). */
         listIndex: number;
+        layoutOptions?: LayoutOptions;
     }): Promise<HTMLLIElement> {
         const li: HTMLLIElement = parentUlElement.createEl('li');
         li.addClasses(['task-list-item', 'plugin-tasks-list-item']);
 
-        let taskAsString = this.toString();
+        let taskAsString = this.toString(layoutOptions);
         const { globalFilter, removeGlobalFilter } = getSettings();
         if (removeGlobalFilter) {
             taskAsString = taskAsString.replace(globalFilter, '').trim();
@@ -263,18 +266,32 @@ export class Task {
         return li;
     }
 
-    public toString(): string {
-        const recurrenceRule: string = this.recurrenceRule
-            ? ` 🔁 ${this.recurrenceRule.toText()}`
-            : '';
-        const dueDate: string = this.dueDate
-            ? ` 📅 ${this.dueDate.format(Task.dateFormat)}`
-            : '';
-        const doneDate: string = this.doneDate
-            ? ` ✅ ${this.doneDate.format(Task.dateFormat)}`
-            : '';
+    public toString(layoutOptions?: LayoutOptions): string {
 
-        return `${this.description}${recurrenceRule}${dueDate}${doneDate}${this.blockLink}`;
+        var taskString = this.description;
+
+        if (layoutOptions == undefined || !layoutOptions.hideRecurrenceRule) {
+            const recurrenceRule: string = this.recurrenceRule
+                ? ` 🔁 ${this.recurrenceRule.toText()}`
+                : '';
+            taskString += recurrenceRule;
+        }
+
+        if (layoutOptions == undefined || !layoutOptions.hideDueDate) {
+            const dueDate: string = this.dueDate
+                ? ` 📅 ${this.dueDate.format(Task.dateFormat)}`
+                : '';
+            taskString += dueDate;
+        }
+
+        if (layoutOptions == undefined || !layoutOptions.hideDoneDate) {
+            const doneDate: string = this.doneDate
+                ? ` ✅ ${this.doneDate.format(Task.dateFormat)}`
+                : '';
+            taskString += doneDate;
+        }
+
+        return taskString;
     }
 
     public toFileLineString(): string {


### PR DESCRIPTION
Hello,
I added the ability to use layout options with task queries. Currently, it only supports "Hide Task Count" and "Hide Backlinks". I think it's a useful feature since for all but one Query I can hide both. This covers parts of #81.

I decided to add it to the query syntax via "layoutOptions:" and a comma separated list. I think like that it should be clear to the user, that it's not part of the filter.

```tasks
not done
path includes Arbeit
layoutOptions: hideTaskcount, hideBacklinks
```
The possibilities are endless and if more layout options will be added maybe it would make sense to refactor it into its own class to use within the query.

Let me know if this is something you would want in your project and/or if needs any changes.
Thanks!
Phil

Fixes #81