### PR TITLE
Wrap whole backlink with a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,19 @@ won't be set to the date correctly.
     ```tasks
     done on {{date:YYYY-MM-DD}}
     ```
+    
+#### Styling Tasks
+
+Each task entry has CSS styles that allow you to change the look and feel of how the tasks are displayed. The 
+following styles are avliable. 
+
+| Class                    | Usage                                                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| plugin-tasks-query-result| This is applied to the UL used to hold all the tasks, each task is stored in a LI.                             |
+| plugin-tasks-list-item   | This is applied to the LI that holds each task and the INPUT element for it.                                   |
+| tasks-backlink           | This is applied to the SPAN that wraps the backlink if displayed on the task.                                  |
+| tasks-edit               | This is applied to the SPAN that wraps the edit button/icon shown next to the task that opens the task edit UI.|
+| task-list-item-checkbox  | This is applied to the INPUT element for the task.                                                             |
 
 ## Development
 Clone the repository, run `yarn` to install the dependencies, and run `yarn dev` to compile the plugin and watch file changes.

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -223,8 +223,11 @@ class QueryRenderChild extends MarkdownRenderChild {
         fileName: string,
         task: Task,
     ) {
-        postInfo.append(' (');
-        const link = postInfo.createEl('a');
+        const span = postInfo.createEl('span');
+        span.addClass('tasks-backlink');
+        span.append(' (');
+
+        const link = span.createEl('a');
         link.href = fileName;
         link.setAttribute('data-href', fileName);
         link.rel = 'noopener';
@@ -246,6 +249,6 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
 
         link.setText(linkText);
-        postInfo.append(')');
+        span.append(')');
     }
 }


### PR DESCRIPTION
I want to be able to style/replace the backlink as needed, on my summary pages I just want to restyle it with a icon like the edit button that takes you to the page it was created on but without all the space taken by the text. This is the most straight forward way I could think of as well as allowing others to style the content.