### PR TITLE
Fix case-insensitive path filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The following filters exist:
 - `is recurring`
 - `is not recurring`
 - `path (includes|does not include) <path>`
+    - Matches case-insensitive (disregards capitalization).
 - `description (includes|does not include) <string>`
     - Matches case-insensitive (disregards capitalization).
 - `heading (includes|does not include) <string>`

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -200,11 +200,15 @@ export class Query {
             const filterMethod = pathMatch[1];
             if (filterMethod === 'includes') {
                 this._filters.push((task: Task) =>
-                    task.path.includes(pathMatch[2]),
+                    this.stringIncludesCaseInsensitive(task.path, pathMatch[2]),
                 );
             } else if (pathMatch[1] === 'does not include') {
                 this._filters.push(
-                    (task: Task) => !task.path.includes(pathMatch[2]),
+                    (task: Task) =>
+                        !this.stringIncludesCaseInsensitive(
+                            task.path,
+                            pathMatch[2],
+                        ),
                 );
             } else {
                 this._error = 'do not understand query filter (path)';


### PR DESCRIPTION
Commit 35494cde82bb38c902b9eb4d30dee161e18a1ef0 introduces a bug, where filtering by path does not work if the file path contains capital letters.

The filter statement is converted into lowercase, but comparing the path with the query is case sensitive.

If the goal is to make filtering by path case-insensitive, this tiny pull request should do it.