### PR TITLE
feat: Add short version of backlinks when in short mode

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -279,6 +279,7 @@ class QueryRenderChild extends MarkdownRenderChild {
       link.setAttribute('data-href', fileName);
       link.rel = 'noopener';
       link.target = '_blank';
+      link.addClass('internal-link');
       link.addClass('internal-link-short-mode');
             
       let linkText = '🔗';

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -185,10 +185,20 @@ class QueryRenderChild extends MarkdownRenderChild {
 
             if (
                 !this.query.layoutOptions.hideBacklinks &&
+                !this.query.layoutOptions.shortMode &&
                 fileName !== undefined
             ) {
                 this.addBacklinks(postInfo, fileName, task);
             }
+            
+
+            if (
+                !this.query.layoutOptions.hideBacklinks &&
+                this.query.layoutOptions.shortMode &&
+                fileName !== undefined
+            ) {
+              this.addShortBacklinks(postInfo, fileName, task);
+            }            
 
             if (!this.query.layoutOptions.hideEditButton) {
                 this.addEditButton(postInfo, task);
@@ -256,4 +266,29 @@ class QueryRenderChild extends MarkdownRenderChild {
         link.setText(linkText);
         postInfo.append(')');
     }
+    
+    private addShortBacklinks(
+        postInfo: HTMLSpanElement,
+        fileName: string,
+        task: Task,
+    ) {
+      postInfo.addClass('tasks-backlink');
+      const link = postInfo.createEl('a');
+            
+      link.href = fileName;
+      link.setAttribute('data-href', fileName);
+      link.rel = 'noopener';
+      link.target = '_blank';
+      link.addClass('internal-link-short-mode');
+            
+      let linkText = '🔗';
+      if (task.precedingHeader !== null) {
+          link.href = link.href + '#' + task.precedingHeader;
+          link.setAttribute(
+              'data-href', 
+              link.getAttribute('data-href') + '#' + task.precedingHeader
+          );
+      }
+      link.setText(linkText);
+  }    
 }

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,10 @@
     cursor: pointer;
 }
 
+.internal-link-short-mode {
+    text-decoration: none;
+}
+
 .tasks-list-text {
     position: relative;
 }

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,7 @@
     cursor: pointer;
 }
 
-.internal-link-short-mode {
+.internal-link.internal-link-short-mode {
     text-decoration: none;
 }
 


### PR DESCRIPTION
I am loving the new short mode and wanted it to also handle making the backlink shorter. This change modifies the query render so the link is rendered as a link icon when `short mode` is specified. 

I am using this on my local copy of the plugin at the moment and it is looking good. 

![image](https://user-images.githubusercontent.com/1399443/140592001-dd0480ec-bdd0-4dd1-a5f5-845cc4c091ba.png)
