### PR TITLE
fix: make description query work against orginal description

### DIFF
--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -80,6 +80,7 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
             sectionIndex: 0,
             precedingHeader: null,
             blockLink: '',
+            originalTaskBody: '',
         });
     }
 
@@ -112,5 +113,6 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
         sectionStart: 0,
         sectionIndex: 0,
         precedingHeader: null,
+        originalTaskBody: '',
     });
 };

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -389,10 +389,14 @@ export class Query {
             if (filterMethod === 'includes') {
                 this._filters.push((task: Task) =>
                     this.stringIncludesCaseInsensitive(
-                        // Remove global filter from description match if present.
+                        // Remove global filter from originalTaskBody match if present.
                         // This is necessary to match only on the content of the task, not
                         // the global filter.
-                        task.description.replace(globalFilter, '').trim(),
+                        // originalTaskBody is used for the description query as it contains
+                        // all the date meta that a user would expect to be there. There
+                        // was a break in functionality that caused issue #399 and this
+                        // resolved it.
+                        task.originalTaskBody.replace(globalFilter, '').trim(),
                         descriptionMatch[2],
                     ),
                 );
@@ -400,10 +404,16 @@ export class Query {
                 this._filters.push(
                     (task: Task) =>
                         !this.stringIncludesCaseInsensitive(
-                            // Remove global filter from description match if present.
+                            // Remove global filter from originalTaskBody match if present.
                             // This is necessary to match only on the content of the task, not
                             // the global filter.
-                            task.description.replace(globalFilter, '').trim(),
+                            // originalTaskBody is used for the description query as it contains
+                            // all the date meta that a user would expect to be there. There
+                            // was a break in functionality that caused issue #399 and this
+                            // resolved it.
+                            task.originalTaskBody
+                                .replace(globalFilter, '')
+                                .trim(),
                             descriptionMatch[2],
                         ),
                 );

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -23,6 +23,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    originalTaskBody: '',
                 }),
                 new Task({
                     status: Status.Todo,
@@ -40,6 +41,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    originalTaskBody: '',
                 }),
             ];
             const input = 'path includes ab/c d';
@@ -133,6 +135,59 @@ describe('Query', () => {
             expect(filteredTasks.length).toEqual(2);
             expect(filteredTasks[0]).toEqual(tasks[1]);
             expect(filteredTasks[1]).toEqual(tasks[2]);
+
+            // Cleanup
+            updateSettings(originalSettings);
+        });
+
+        it('description filters out emoji for does not include', () => {
+            // Arrange
+            const originalSettings = getSettings();
+            updateSettings({ globalFilter: '#task' });
+            const tasks: Task[] = [
+                Task.fromLine({
+                    line: '- [ ] #task this does not include the word; only in the global filter',
+                    sectionStart: 0,
+                    sectionIndex: 0,
+                    path: '',
+                    precedingHeader: '',
+                }),
+                Task.fromLine({
+                    line: '- [ ] #task this does: task',
+                    sectionStart: 0,
+                    sectionIndex: 0,
+                    path: '',
+                    precedingHeader: '',
+                }),
+                Task.fromLine({
+                    line: '- [ ] #task Do something on this date 📅 2021-07-09',
+                    sectionStart: 0,
+                    sectionIndex: 0,
+                    path: '',
+                    precedingHeader: '',
+                }),
+                Task.fromLine({
+                    line: '- [x] #task This was done! ✅ 2021-08-09 ',
+                    sectionStart: 0,
+                    sectionIndex: 0,
+                    path: '',
+                    precedingHeader: '',
+                }),
+            ] as Task[];
+            const input = 'description does not include 📅';
+            const query = new Query({ source: input });
+
+            // Act
+            let filteredTasks = [...tasks];
+            query.filters.forEach((filter) => {
+                filteredTasks = filteredTasks.filter(filter);
+            });
+
+            // Assert
+            expect(filteredTasks.length).toEqual(3);
+            expect(filteredTasks[0]).toEqual(tasks[0]);
+            expect(filteredTasks[1]).toEqual(tasks[1]);
+            expect(filteredTasks[2]).toEqual(tasks[3]);
 
             // Cleanup
             updateSettings(originalSettings);


### PR DESCRIPTION
This resolves #399 where a change in functionality caused description
to lose the date information. It was parsed out and replace with a
empty string. By introducing a property for the orginal task body the
description query can match pre-exisiting functionality while still
preserving description as it is used now.