### PR TITLE
Using full path for backlinks

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -233,8 +233,8 @@ class QueryRenderChild extends MarkdownRenderChild {
         postInfo.append(' (');
         const link = postInfo.createEl('a');
 
-        link.href = fileName;
-        link.setAttribute('data-href', fileName);
+        link.href = task.path;
+        link.setAttribute('data-href', task.path);
         link.rel = 'noopener';
         link.target = '_blank';
         link.addClass('internal-link');


### PR DESCRIPTION
Using only the basename to identify a markdown document creates confusion on what document should be shown, as it is possible in obsidian to have multiple documents with the same basename. Instead, using a full path could uniquely identify the document. This partially solves #396