### PR TITLE
Add happens query for tasks

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -267,39 +267,27 @@ export class Query {
             let filter;
             if (happensMatch[1] === 'before') {
                 filter = (task: Task) => {
-                    if (task.startDate) {
-                        return task.startDate.isBefore(filterDate);
-                    } else if (task.scheduledDate) {
-                        return task.scheduledDate.isBefore(filterDate);
-                    } else if (task.dueDate) {
-                        return task.dueDate.isBefore(filterDate);
-                    } else {
-                        return false;
-                    }
+                    return Array.of(
+                        task.startDate,
+                        task.scheduledDate,
+                        task.dueDate,
+                    ).some((date) => date && date.isBefore(filterDate));
                 };
             } else if (happensMatch[1] === 'after') {
                 filter = (task: Task) => {
-                    if (task.startDate) {
-                        return task.startDate.isAfter(filterDate);
-                    } else if (task.scheduledDate) {
-                        return task.scheduledDate.isAfter(filterDate);
-                    } else if (task.dueDate) {
-                        return task.dueDate.isAfter(filterDate);
-                    } else {
-                        return false;
-                    }
+                    return Array.of(
+                        task.startDate,
+                        task.scheduledDate,
+                        task.dueDate,
+                    ).some((date) => date && date.isAfter(filterDate));
                 };
             } else {
                 filter = (task: Task) => {
-                    if (task.startDate) {
-                        return task.startDate.isSame(filterDate);
-                    } else if (task.scheduledDate) {
-                        return task.scheduledDate.isSame(filterDate);
-                    } else if (task.dueDate) {
-                        return task.dueDate.isSame(filterDate);
-                    } else {
-                        return false;
-                    }
+                    return Array.of(
+                        task.startDate,
+                        task.scheduledDate,
+                        task.dueDate,
+                    ).some((date) => date && date.isSame(filterDate));
                 };
             }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -26,6 +26,8 @@ export class Query {
     private readonly priorityRegexp =
         /^priority (is )?(above|below)? ?(low|none|medium|high)/;
 
+    private readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
+
     private readonly noStartString = 'no start date';
     private readonly startRegexp = /^starts (before|after|on)? ?(.*)/;
 
@@ -103,6 +105,9 @@ export class Query {
                         break;
                     case this.priorityRegexp.test(line):
                         this.parsePriorityFilter({ line });
+                        break;
+                    case this.happensRegexp.test(line):
+                        this.parseHappensFilter({ line });
                         break;
                     case this.startRegexp.test(line):
                         this.parseStartFilter({ line });
@@ -247,6 +252,60 @@ export class Query {
             this._filters.push(filter);
         } else {
             this._error = 'do not understand query filter (priority date)';
+        }
+    }
+
+    private parseHappensFilter({ line }: { line: string }): void {
+        const happensMatch = line.match(this.happensRegexp);
+        if (happensMatch !== null) {
+            const filterDate = this.parseDate(happensMatch[2]);
+            if (!filterDate.isValid()) {
+                this._error = 'do not understand happens date';
+                return;
+            }
+
+            let filter;
+            if (happensMatch[1] === 'before') {
+                filter = (task: Task) => {
+                    if (task.startDate) {
+                        return task.startDate.isBefore(filterDate);
+                    } else if (task.scheduledDate) {
+                        return task.scheduledDate.isBefore(filterDate);
+                    } else if (task.dueDate) {
+                        return task.dueDate.isBefore(filterDate);
+                    } else {
+                        return false;
+                    }
+                };
+            } else if (happensMatch[1] === 'after') {
+                filter = (task: Task) => {
+                    if (task.startDate) {
+                        return task.startDate.isAfter(filterDate);
+                    } else if (task.scheduledDate) {
+                        return task.scheduledDate.isAfter(filterDate);
+                    } else if (task.dueDate) {
+                        return task.dueDate.isAfter(filterDate);
+                    } else {
+                        return false;
+                    }
+                };
+            } else {
+                filter = (task: Task) => {
+                    if (task.startDate) {
+                        return task.startDate.isSame(filterDate);
+                    } else if (task.scheduledDate) {
+                        return task.scheduledDate.isSame(filterDate);
+                    } else if (task.dueDate) {
+                        return task.dueDate.isSame(filterDate);
+                    } else {
+                        return false;
+                    }
+                };
+            }
+
+            this._filters.push(filter);
+        } else {
+            this._error = 'do not understand query filter (happens date)';
         }
     }
 


### PR DESCRIPTION
### What it does?
It's a new query string, which searchs for all the date types: _starting, scheduled, due_ and outputs it. 

### Why is it needed?
Currently you can't query just by date, due, starting and scheduled are all seperated, so you need multiple tasks queries. I think it will be helpful to just see what is coming tomorrow from all sorts of date types set to that date.

### Example Usage
```tasks
not done
happens on tomorrow
```
### Features
It support the "after" and "before" query as well and it will respect start dates first, in case of multiple date types added to the task.
```tasks
not done
happens before today
```

If you don't want a certain date time shown, you can use the default filter:
`no scheduled date`

```tasks
not done
no scheduled date
happens after today
happens before in 1 week
```