### PR TITLE
Add support for comments inside task blocks

### DIFF
--- a/docs/queries/comments.md
+++ b/docs/queries/comments.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Comments
+nav_order: 5
+parent: Queries
+has_toc: false
+---
+
+# Comments
+
+All query lines beginning with a `#` character are treated as
+comments, and will be ignored.
+
+Example:
+
+    ```tasks
+    not done
+    # Uncomment the following line to enable short mode:
+    # short mode
+    ```

--- a/docs/queries/examples.md
+++ b/docs/queries/examples.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Examples
-nav_order: 5
+nav_order: 6
 parent: Queries
 has_toc: false
 ---

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -58,6 +58,8 @@ export class Query {
     private readonly limitRegexp = /^limit (to )?(\d+)( tasks?)?/;
     private readonly excludeSubItemsString = 'exclude sub-items';
 
+    private readonly commentRegexp = /^#.*/;
+
     constructor({ source }: { source: string }) {
         source
             .split('\n')
@@ -131,6 +133,9 @@ export class Query {
                         break;
                     case this.hideOptionsRegexp.test(line):
                         this.parseHideOptions({ line });
+                        break;
+                    case this.commentRegexp.test(line):
+                        // Comment lines are ignored
                         break;
                     default:
                         this._error = 'do not understand query';

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -162,4 +162,14 @@ describe('Query', () => {
             expect(query.sorting).toEqual(output);
         });
     });
+    describe('comments', () => {
+        it('ignores comments', () => {
+            // Arrange
+            const input = '# I am a comment, which will be ignored';
+            const query = new Query({ source: input });
+
+            // Assert
+            expect(query.error).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
I've added a test, and confirmed that it failed before I added the code to ignore comments.
And I've added brief docs, with an example.

As discussed in:

https://github.com/schemar/obsidian-tasks/discussions/531
> Add support for 'comment' instruction

