### PR TITLE
Fix: No longer crash when toggling a recurring task without any date

### DIFF
--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -84,7 +84,7 @@ export class Recurrence {
                     referenceDate = window.moment();
                 }
 
-                if (!baseOnToday && referenceDate !== null) {
+                if (!baseOnToday) {
                     options.dtstart = window
                         .moment(referenceDate)
                         .startOf('day')

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -80,6 +80,8 @@ export class Recurrence {
                     referenceDate = window.moment(scheduledDate);
                 } else if (startDate) {
                     referenceDate = window.moment(startDate);
+                } else {
+                    referenceDate = window.moment();
                 }
 
                 if (!baseOnToday && referenceDate !== null) {

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -21,7 +21,7 @@ export class Recurrence {
      * same relative distance to the due date as the original task. For example
      * "starts one week before it is due".
      */
-    private readonly referenceDate: Moment | null;
+    private readonly referenceDate: Moment;
 
     constructor({
         rrule,
@@ -33,7 +33,7 @@ export class Recurrence {
     }: {
         rrule: RRule;
         baseOnToday: boolean;
-        referenceDate: Moment | null;
+        referenceDate: Moment;
         startDate: Moment | null;
         scheduledDate: Moment | null;
         dueDate: Moment | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -361,6 +361,9 @@ describe('toggle done', () => {
             nextScheduled: '2021-10-18',
             nextDue: '2021-10-20',
         },
+        {
+            interval: 'every week',
+        },
     ];
 
     test.concurrent.each<RecurrenceCase>(recurrenceCases)(


### PR DESCRIPTION
A recurring task without a reference date should recur based on today. The code wrongly assumed that `moment(null)` defaults to today, but that is actually not the case. `moment(undefined)` must be used instead.

Fixes #595 