### PR TITLE
Add `has <start|scheduled|due> date` filters

### DIFF
--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -89,6 +89,7 @@ Instead you would have two queries, one for each condition:
 ### Start Date
 
 -   `no start date`
+-   `has start date`
 -   `starts (before|after|on) <date>`
 
 When filtering queries by [start date]({{ site.baseurl }}{% link getting-started/dates.md %}#-start),
@@ -104,11 +105,13 @@ Such filter could be:
 ### Scheduled Date
 
 -   `no scheduled date`
+-   `has scheduled date`
 -   `scheduled (before|after|on) <date>`
 
 ### Due Date
 
 -   `no due date`
+-   `has due date`
 -   `due (before|after|on) <date>`
 
 ### Happens

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -29,12 +29,15 @@ export class Query {
     private readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
 
     private readonly noStartString = 'no start date';
+    private readonly hasStartString = 'has start date';
     private readonly startRegexp = /^starts (before|after|on)? ?(.*)/;
 
     private readonly noScheduledString = 'no scheduled date';
+    private readonly hasScheduledString = 'has scheduled date';
     private readonly scheduledRegexp = /^scheduled (before|after|on)? ?(.*)/;
 
     private readonly noDueString = 'no due date';
+    private readonly hasDueString = 'has due date';
     private readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
     private readonly doneString = 'done';
@@ -99,6 +102,17 @@ export class Query {
                         break;
                     case line === this.noDueString:
                         this._filters.push((task) => task.dueDate === null);
+                        break;
+                    case line === this.hasStartString:
+                        this._filters.push((task) => task.startDate !== null);
+                        break;
+                    case line === this.hasScheduledString:
+                        this._filters.push(
+                            (task) => task.scheduledDate !== null,
+                        );
+                        break;
+                    case line === this.hasDueString:
+                        this._filters.push((task) => task.dueDate !== null);
                         break;
                     case this.shortModeRegexp.test(line):
                         this._layoutOptions.shortMode = true;

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -232,6 +232,48 @@ describe('Query', () => {
                     expectedResult: ['- [ ] task 1'],
                 },
             ],
+            [
+                'by start date (before)',
+                {
+                    filters: ['starts before 2022-04-20'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-15',
+                        '- [ ] task 3 🛫 2022-04-20',
+                        '- [ ] task 4 🛫 2022-04-25',
+                    ],
+                    expectedResult: [
+                        '- [ ] task 1', // reference: https://schemar.github.io/obsidian-tasks/queries/filters/#start-date
+                        '- [ ] task 2 🛫 2022-04-15',
+                    ],
+                },
+            ],
+            [
+                'by due date (before)',
+                {
+                    filters: ['due before 2022-04-20'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 📅 2022-04-15',
+                        '- [ ] task 3 📅 2022-04-20',
+                        '- [ ] task 4 📅 2022-04-25',
+                    ],
+                    expectedResult: ['- [ ] task 2 📅 2022-04-15'],
+                },
+            ],
+            [
+                'by scheduled date (before)',
+                {
+                    filters: ['scheduled before 2022-04-20'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 ⏳ 2022-04-15',
+                        '- [ ] task 3 ⏳ 2022-04-20',
+                        '- [ ] task 4 ⏳ 2022-04-25',
+                    ],
+                    expectedResult: ['- [ ] task 2 ⏳ 2022-04-15'],
+                },
+            ],
         ])(
             'should support filtering %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -143,6 +143,125 @@ describe('Query', () => {
             // Cleanup
             updateSettings(originalSettings);
         });
+
+        type FilteringCase = {
+            filters: Array<string>;
+            tasks: Array<string>;
+            expectedResult: Array<string>;
+        };
+
+        test.concurrent.each<[string, FilteringCase]>([
+            [
+                'by due date presence',
+                {
+                    filters: ['has due date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 📅 2022-04-20',
+                    ],
+                    expectedResult: [
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 📅 2022-04-20',
+                    ],
+                },
+            ],
+            [
+                'by start date presence',
+                {
+                    filters: ['has start date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 🛫 2022-04-20',
+                    ],
+                    expectedResult: [
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 🛫 2022-04-20',
+                    ],
+                },
+            ],
+            [
+                'by scheduled date presence',
+                {
+                    filters: ['has scheduled date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 ⏳ 2022-04-20',
+                    ],
+                    expectedResult: [
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 ⏳ 2022-04-20',
+                    ],
+                },
+            ],
+            [
+                'by due date absence',
+                {
+                    filters: ['no due date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 📅 2022-04-20',
+                    ],
+                    expectedResult: ['- [ ] task 1'],
+                },
+            ],
+            [
+                'by start date absence',
+                {
+                    filters: ['no start date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 🛫 2022-04-20',
+                    ],
+                    expectedResult: ['- [ ] task 1'],
+                },
+            ],
+            [
+                'by scheduled date absence',
+                {
+                    filters: ['no scheduled date'],
+                    tasks: [
+                        '- [ ] task 1',
+                        '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
+                        '- [ ] task 3 ⏳ 2022-04-20',
+                    ],
+                    expectedResult: ['- [ ] task 1'],
+                },
+            ],
+        ])(
+            'should support filtering %s',
+            (_, { tasks: allTaskLines, filters, expectedResult }) => {
+                // Arrange
+                const query = new Query({ source: filters.join('\n') });
+
+                const tasks = allTaskLines.map(
+                    (taskLine) =>
+                        Task.fromLine({
+                            line: taskLine,
+                            sectionStart: 0,
+                            sectionIndex: 0,
+                            path: '',
+                            precedingHeader: '',
+                        }) as Task,
+                );
+
+                // Act
+                let filteredTasks = [...tasks];
+                query.filters.forEach((filter) => {
+                    filteredTasks = filteredTasks.filter(filter);
+                });
+
+                // Assert
+                const filteredTaskLines = filteredTasks.map(
+                    (task) => `- [ ] ${task.toString()}`,
+                );
+                expect(filteredTaskLines).toMatchObject(expectedResult);
+            },
+        );
     });
 
     describe('filtering with "happens"', () => {


### PR DESCRIPTION
Added support for filtering by date presence using the format `has <start|scheduled|due> date`. I've been using the start date presence filter specifically in my vault for a little while now to enable a "tickler" system which has been quite helpful; adding support for scheduled and due at the same time was simple enough to do.

I also revisited my strategy for testing slightly with the tests introduced by this PR around recent discussions we have had in the various issues. cc @claremacrae 
