### PR TITLE
Add tags as property of task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# See http://EditorConfig.org for more information about .editorconfig files.
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.xml]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{md,mdx}]
+trim_trailing_whitespace = true
+
+[*.{htm,html,js,jsm,ts,tsx,mjs}]
+indent_size = 4
+
+[*.{cmd,bat,ps1}]
+end_of_line = crlf
+
+[*.sh]
+end_of_line = lf
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Every contribution is much appreciated!
 ## Updating documentation
 
 The documentation resides under the `./docs` directory.
-It consists of markdown files, which [Jekyll](https://jekyllrb.com/) will transform into web pages that you can view at https://schemar.github.io/obsidian-tasks/ .
+It consists of markdown files, which [Jekyll](https://jekyllrb.com/) will transform into web pages that you can view at <https://schemar.github.io/obsidian-tasks/> .
 In the simplest case, you can update the existing markdown file and create a pull request (PR) with your changes.
 
 We use [GitHub pages](https://pages.github.com/) for our documentation.
 You can read more about it at their [official documentation](https://docs.github.com/en/pages).
 
-For documentation changes to show up at https://schemar.github.io/obsidian-tasks/ , they must be in the `gh-pages` branch.
+For documentation changes to show up at <https://schemar.github.io/obsidian-tasks/> , they must be in the `gh-pages` branch.
 If you want to see your changes available immediately and not only after the next release, you should make your changes on the `gh-pages` branch.
 When you create a PR, it should merge into the `gh-pages` branch as well.
 If you document an unreleased feature, you should update the documentation on `main` instead. Ideally together with the related code changes.
@@ -29,6 +29,21 @@ Discussion will take place inside the PR.
 
 If you can, please add/update tests and documentation where appropriate.
 
+## Setting up build environment
+
+This project uses Node 14.x, if you need to use a different version, look at using `nvm` to manage your Node versions. If you are using `nvm`, you can install the 14.x version of Node with `nvm install 14.19.1; nvm use 14.19.1`.
+
+To setup the local environment after cloning the repository, run the following commands:
+
+``` shell
+yarn
+yarn build
+yarn test
+yarn lint
+```
+
+Make sure you build, test and lint before pushing to the repository.
+
 ## FAQs
 
 ### How does Tasks handle status changes?
@@ -42,15 +57,15 @@ You can toggle a task‘s status by:
 
 The code is located as follows:
 
--   For 1.: ``./src/Commands/ToggleDone.ts`
--   2. and 4. use a checkbox created by `Task.toLi()`. There, the checkbox gets a click event handler.
--   For 3.: `./src/LivePreviewExtension.ts`
+- For 1.: ``./src/Commands/ToggleDone.ts`
+- 2. and 4. use a checkbox created by `Task.toLi()`. There, the checkbox gets a click event handler.
+- For 3.: `./src/LivePreviewExtension.ts`
 
 Toggle behavior:
 
--   1. toggles the line directly where the cursor is. In the file inside Obsidian‘s vault.
--   The click event listener of 2. and 4. uses File::replaceTaskWithTasks(). That, in turn, updates the file in Obsidian‘s Vault (like 1, but it needs to find the correct line).
--   3. toggles the line directly where the checkbox is. On the „document“ of CodeMirror (the library that Obsidian uses to show text on screen). That, in turn, updates the file in Obsidian‘s Vault, somehow.
+- 1. toggles the line directly where the cursor is. In the file inside Obsidian‘s vault.
+- The click event listener of 2. and 4. uses File::replaceTaskWithTasks(). That, in turn, updates the file in Obsidian‘s Vault (like 1, but it needs to find the correct line).
+- 3. toggles the line directly where the checkbox is. On the „document“ of CodeMirror (the library that Obsidian uses to show text on screen). That, in turn, updates the file in Obsidian‘s Vault, somehow.
 
 Obsidian writes the changes to disk at its own pace.
 

--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -80,6 +80,7 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
             sectionIndex: 0,
             precedingHeader: null,
             blockLink: '',
+            tags: [],
         });
     }
 
@@ -112,5 +113,6 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
         sectionStart: 0,
         sectionIndex: 0,
         precedingHeader: null,
+        tags: [],
     });
 };

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -13,7 +13,8 @@ export type SortingProperty =
     | 'due'
     | 'done'
     | 'path'
-    | 'description';
+    | 'description'
+    | 'tag';
 type Sorting = { property: SortingProperty; reverse: boolean };
 
 export class Query {
@@ -44,8 +45,11 @@ export class Query {
     private readonly pathRegexp = /^path (includes|does not include) (.*)/;
     private readonly descriptionRegexp =
         /^description (includes|does not include) (.*)/;
+
+    private readonly tagRegexp = /^tag (includes|does not include) (.*)/;
+
     private readonly sortByRegexp =
-        /^sort by (urgency|status|priority|start|scheduled|due|done|path|description)( reverse)?/;
+        /^sort by (urgency|status|priority|start|scheduled|due|done|path|description|tag)( reverse)?/;
 
     private readonly headingRegexp =
         /^heading (includes|does not include) (.*)/;
@@ -126,6 +130,9 @@ export class Query {
                         break;
                     case this.descriptionRegexp.test(line):
                         this.parseDescriptionFilter({ line });
+                        break;
+                    case this.tagRegexp.test(line):
+                        this.parseTagFilter({ line });
                         break;
                     case this.headingRegexp.test(line):
                         this.parseHeadingFilter({ line });
@@ -429,6 +436,29 @@ export class Query {
             }
         } else {
             this._error = 'do not understand query filter (path)';
+        }
+    }
+
+    private parseTagFilter({ line }: { line: string }): void {
+        const tagMatch = line.match(this.tagRegexp);
+        if (tagMatch !== null) {
+            const filterMethod = tagMatch[1];
+
+            if (filterMethod === 'includes') {
+                this._filters.push(
+                    (task: Task) =>
+                        task.tags.find((el) => el === tagMatch[2]) != undefined,
+                );
+            } else if (tagMatch[1] === 'does not include') {
+                this._filters.push(
+                    (task: Task) =>
+                        task.tags.find((el) => el === tagMatch[2]) == undefined,
+                );
+            } else {
+                this._error = 'do not understand query filter (tag)';
+            }
+        } else {
+            this._error = 'do not understand query filter (tag)';
         }
     }
 

--- a/src/Sort.ts
+++ b/src/Sort.ts
@@ -43,6 +43,7 @@ export class Sort {
         done: Sort.compareByDoneDate,
         path: Sort.compareByPath,
         status: Sort.compareByStatus,
+        tag: Sort.compareByTag,
     };
 
     private static makeReversedComparator(comparator: Comparator): Comparator {
@@ -96,6 +97,17 @@ export class Sort {
 
     private static compareByDoneDate(a: Task, b: Task): -1 | 0 | 1 {
         return Sort.compareByDate(a.doneDate, b.doneDate);
+    }
+
+    // Currently sorts by first tag found only.
+    private static compareByTag(a: Task, b: Task): -1 | 0 | 1 {
+        if (a.tags[0] < b.tags[0]) {
+            return -1;
+        } else if (a.tags[0] > b.tags[0]) {
+            return 1;
+        } else {
+            return 0;
+        }
     }
 
     private static compareByDate(

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -29,6 +29,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    tags: [],
                 }),
                 new Task({
                     status: Status.Todo,
@@ -46,6 +47,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    tags: [],
                 }),
             ];
             const input = 'path includes ab/c d';
@@ -143,6 +145,95 @@ describe('Query', () => {
             // Cleanup
             updateSettings(originalSettings);
         });
+    });
+
+    it('filters based off a single tag', () => {
+        // Arrange
+        const originalSettings = getSettings();
+        updateSettings({ globalFilter: '#task' });
+        const tasks: Task[] = [
+            Task.fromLine({
+                line: '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+            Task.fromLine({
+                line: '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+            Task.fromLine({
+                line: '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+        ] as Task[];
+        const input = 'tag includes #home';
+        const query = new Query({ source: input });
+
+        // Act
+        let filteredTasks = [...tasks];
+        query.filters.forEach((filter) => {
+            filteredTasks = filteredTasks.filter(filter);
+        });
+
+        // Assert
+        expect(filteredTasks.length).toEqual(1);
+        expect(filteredTasks[0]).toEqual(tasks[1]);
+
+        // Cleanup
+        updateSettings(originalSettings);
+    });
+
+    it('filters based off a tag not being present', () => {
+        // Arrange
+        const originalSettings = getSettings();
+        updateSettings({ globalFilter: '#task' });
+        const tasks: Task[] = [
+            Task.fromLine({
+                line: '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+            Task.fromLine({
+                line: '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+            Task.fromLine({
+                line: '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }),
+        ] as Task[];
+        const input = 'tag does not include #home';
+        const query = new Query({ source: input });
+
+        // Act
+        let filteredTasks = [...tasks];
+        query.filters.forEach((filter) => {
+            filteredTasks = filteredTasks.filter(filter);
+        });
+
+        // Assert
+        expect(filteredTasks.length).toEqual(2);
+        expect(filteredTasks[0]).toEqual(tasks[0]);
+        expect(filteredTasks[1]).toEqual(tasks[2]);
+
+        // Cleanup
+        updateSettings(originalSettings);
     });
 
     describe('filtering with "happens"', () => {

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -228,4 +228,39 @@ describe('Sort', () => {
             ),
         ).toEqual(expectedOrder);
     });
+
+    it('sorts correctly by tag, done', () => {
+        const one = fromLine({
+            line: '- [ ] a #someday #home 📅 1970-01-01 ✅ 1971-01-01',
+            path: '',
+        });
+        const two = fromLine({
+            line: '- [ ] #task b #someday #home 📅 1970-01-02 ✅ 1971-01-02',
+            path: '',
+        });
+        const three = fromLine({
+            line: '- [ ] c #next #home 📅 1970-01-02 ✅ 1971-01-01',
+            path: '',
+        });
+        const four = fromLine({
+            line: '- [ ] d #urgent #home 📅 1970-01-02 ✅ 1971-01-03',
+            path: '',
+        });
+        const five = fromLine({
+            line: '- [ ] e 📅 1970-01-02 ✅ 1971-01-03',
+            path: '',
+        });
+        const expectedOrder = [three, one, two, four, five];
+        expect(
+            Sort.by(
+                {
+                    sorting: [
+                        { property: 'tag', reverse: false },
+                        { property: 'done', reverse: false },
+                    ],
+                },
+                [one, two, three, four, five],
+            ),
+        ).toEqual(expectedOrder);
+    });
 });


### PR DESCRIPTION
Add the collection of tags as a property of a Task, this allows for running a query against the tags directly. Long term I want to look at adding group by tags. Makes the GTD process simpler.

Changes:

- Add dev setup to contributing
- Add tags as a property of task
- Add query by tag in query language
- Add sort by tag
- Added unit tests for coverage
- Markdown lint fixes