### PR TITLE
Simplify tag filter tests

### DIFF
--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -8,6 +8,38 @@ import { Priority, Status, Task } from '../src/Task';
 
 window.moment = moment;
 
+function shouldSupportFiltering(
+    filters: Array<string>,
+    allTaskLines: Array<string>,
+    expectedResult: Array<string>,
+) {
+    // Arrange
+    const query = new Query({ source: filters.join('\n') });
+
+    const tasks = allTaskLines.map(
+        (taskLine) =>
+            Task.fromLine({
+                line: taskLine,
+                sectionStart: 0,
+                sectionIndex: 0,
+                path: '',
+                precedingHeader: '',
+            }) as Task,
+    );
+
+    // Act
+    let filteredTasks = [...tasks];
+    query.filters.forEach((filter) => {
+        filteredTasks = filteredTasks.filter(filter);
+    });
+
+    // Assert
+    const filteredTaskLines = filteredTasks.map(
+        (task) => `- [ ] ${task.toString()}`,
+    );
+    expect(filteredTaskLines).toMatchObject(expectedResult);
+}
+
 describe('Query', () => {
     describe('filtering', () => {
         it('filters paths case insensitive', () => {
@@ -279,31 +311,7 @@ describe('Query', () => {
         ])(
             'should support filtering %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {
-                // Arrange
-                const query = new Query({ source: filters.join('\n') });
-
-                const tasks = allTaskLines.map(
-                    (taskLine) =>
-                        Task.fromLine({
-                            line: taskLine,
-                            sectionStart: 0,
-                            sectionIndex: 0,
-                            path: '',
-                            precedingHeader: '',
-                        }) as Task,
-                );
-
-                // Act
-                let filteredTasks = [...tasks];
-                query.filters.forEach((filter) => {
-                    filteredTasks = filteredTasks.filter(filter);
-                });
-
-                // Assert
-                const filteredTaskLines = filteredTasks.map(
-                    (task) => `- [ ] ${task.toString()}`,
-                );
-                expect(filteredTaskLines).toMatchObject(expectedResult);
+                shouldSupportFiltering(filters, allTaskLines, expectedResult);
             },
         );
     });

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -320,41 +320,18 @@ describe('Query', () => {
         // Arrange
         const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
-        const tasks: Task[] = [
-            Task.fromLine({
-                line: '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-            Task.fromLine({
-                line: '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-            Task.fromLine({
-                line: '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-        ] as Task[];
-        const input = 'tag includes #home';
-        const query = new Query({ source: input });
+        const filters = ['tag includes #home'];
+        const tasks = [
+            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+        ];
 
-        // Act
-        let filteredTasks = [...tasks];
-        query.filters.forEach((filter) => {
-            filteredTasks = filteredTasks.filter(filter);
-        });
-
-        // Assert
-        expect(filteredTasks.length).toEqual(1);
-        expect(filteredTasks[0]).toEqual(tasks[1]);
+        // Act, Assert
+        const expectedResult: Array<string> = [
+            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+        ];
+        shouldSupportFiltering(filters, tasks, expectedResult);
 
         // Cleanup
         updateSettings(originalSettings);

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -315,6 +315,7 @@ describe('Query', () => {
             },
         );
     });
+
     describe('filtering with "tag" and global task filter', () => {
         test.concurrent.each<[string, FilteringCase]>([
             [

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -316,48 +316,49 @@ describe('Query', () => {
         );
     });
     describe('filtering with "tag" and global task filter', () => {
-        it('filters based off a single tag', () => {
-            // Arrange
-            const originalSettings = getSettings();
-            updateSettings({ globalFilter: '#task' });
-            const filters = ['tag includes #home'];
-            const tasks = [
-                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-            ];
+        test.concurrent.each<[string, FilteringCase]>([
+            [
+                'by tag presence',
+                {
+                    filters: ['tag includes #home'],
+                    tasks: [
+                        '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                        '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                        '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+                    ],
+                    expectedResult: [
+                        '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                    ],
+                },
+            ],
+            [
+                'by tag absence',
+                {
+                    filters: ['tag does not include #home'],
+                    tasks: [
+                        '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                        '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                        '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+                    ],
+                    expectedResult: [
+                        '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                        '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+                    ],
+                },
+            ],
+        ])(
+            'should support filtering of tags %s',
+            (_, { tasks: allTaskLines, filters, expectedResult }) => {
+                // Arrange
+                const originalSettings = getSettings();
+                updateSettings({ globalFilter: '#task' });
 
-            // Act, Assert
-            const expectedResult: Array<string> = [
-                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-            ];
-            shouldSupportFiltering(filters, tasks, expectedResult);
+                shouldSupportFiltering(filters, allTaskLines, expectedResult);
 
-            // Cleanup
-            updateSettings(originalSettings);
-        });
-
-        it('filters based off a tag not being present', () => {
-            // Arrange
-            const originalSettings = getSettings();
-            updateSettings({ globalFilter: '#task' });
-            const filters = ['tag does not include #home'];
-            const tasks = [
-                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-            ];
-
-            // Act, Assert
-            const expectedResult: Array<string> = [
-                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-            ];
-            shouldSupportFiltering(filters, tasks, expectedResult);
-
-            // Cleanup
-            updateSettings(originalSettings);
-        });
+                // Cleanup
+                updateSettings(originalSettings);
+            },
+        );
     });
 
     describe('filtering with "happens"', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -315,48 +315,49 @@ describe('Query', () => {
             },
         );
     });
+    describe('filtering with "tag" and global task filter', () => {
+        it('filters based off a single tag', () => {
+            // Arrange
+            const originalSettings = getSettings();
+            updateSettings({ globalFilter: '#task' });
+            const filters = ['tag includes #home'];
+            const tasks = [
+                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+            ];
 
-    it('filters based off a single tag', () => {
-        // Arrange
-        const originalSettings = getSettings();
-        updateSettings({ globalFilter: '#task' });
-        const filters = ['tag includes #home'];
-        const tasks = [
-            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-        ];
+            // Act, Assert
+            const expectedResult: Array<string> = [
+                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+            ];
+            shouldSupportFiltering(filters, tasks, expectedResult);
 
-        // Act, Assert
-        const expectedResult: Array<string> = [
-            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-        ];
-        shouldSupportFiltering(filters, tasks, expectedResult);
+            // Cleanup
+            updateSettings(originalSettings);
+        });
 
-        // Cleanup
-        updateSettings(originalSettings);
-    });
+        it('filters based off a tag not being present', () => {
+            // Arrange
+            const originalSettings = getSettings();
+            updateSettings({ globalFilter: '#task' });
+            const filters = ['tag does not include #home'];
+            const tasks = [
+                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+            ];
 
-    it('filters based off a tag not being present', () => {
-        // Arrange
-        const originalSettings = getSettings();
-        updateSettings({ globalFilter: '#task' });
-        const filters = ['tag does not include #home'];
-        const tasks = [
-            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-        ];
+            // Act, Assert
+            const expectedResult: Array<string> = [
+                '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+                '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+            ];
+            shouldSupportFiltering(filters, tasks, expectedResult);
 
-        // Act, Assert
-        const expectedResult: Array<string> = [
-            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-        ];
-        shouldSupportFiltering(filters, tasks, expectedResult);
-
-        // Cleanup
-        updateSettings(originalSettings);
+            // Cleanup
+            updateSettings(originalSettings);
+        });
     });
 
     describe('filtering with "happens"', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -8,6 +8,12 @@ import { Priority, Status, Task } from '../src/Task';
 
 window.moment = moment;
 
+type FilteringCase = {
+    filters: Array<string>;
+    tasks: Array<string>;
+    expectedResult: Array<string>;
+};
+
 function shouldSupportFiltering(
     filters: Array<string>,
     allTaskLines: Array<string>,
@@ -177,12 +183,6 @@ describe('Query', () => {
             // Cleanup
             updateSettings(originalSettings);
         });
-
-        type FilteringCase = {
-            filters: Array<string>;
-            tasks: Array<string>;
-            expectedResult: Array<string>;
-        };
 
         test.concurrent.each<[string, FilteringCase]>([
             [

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -341,42 +341,19 @@ describe('Query', () => {
         // Arrange
         const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
-        const tasks: Task[] = [
-            Task.fromLine({
-                line: '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-            Task.fromLine({
-                line: '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-            Task.fromLine({
-                line: '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }),
-        ] as Task[];
-        const input = 'tag does not include #home';
-        const query = new Query({ source: input });
+        const filters = ['tag does not include #home'];
+        const tasks = [
+            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+            '- [ ] #task something to do #later #home 📅 2021-09-12 ✅ 2021-06-20',
+            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+        ];
 
-        // Act
-        let filteredTasks = [...tasks];
-        query.filters.forEach((filter) => {
-            filteredTasks = filteredTasks.filter(filter);
-        });
-
-        // Assert
-        expect(filteredTasks.length).toEqual(2);
-        expect(filteredTasks[0]).toEqual(tasks[0]);
-        expect(filteredTasks[1]).toEqual(tasks[2]);
+        // Act, Assert
+        const expectedResult: Array<string> = [
+            '- [ ] #task something to do #later #work 📅 2021-09-12 ✅ 2021-06-20',
+            '- [ ] #task get the milk 📅 2021-09-12 ✅ 2021-06-20',
+        ];
+        shouldSupportFiltering(filters, tasks, expectedResult);
 
         // Cleanup
         updateSettings(originalSettings);


### PR DESCRIPTION
This:

1. refactors the `'should support filtering %s'` tests so that their code can be re-used in other tests in `Query.test.ts`
2. refactors the tag filtering tests to re-use the above. 

Effectively, this reuses the pattern that @mauleb invented in #629, so that it's easier to see the input and output of filtering tests, and easier to add further tests in future.

