### PR TITLE
Simplify more tests of Query

### DIFF
--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -447,36 +447,23 @@ describe('Query', () => {
                 taskShouldMatch,
             }) => {
                 // Arrange
-                const query = new Query({ source: happensFilter });
-
                 const line = [
                     '- [ ] this is a task',
+                    !!start && `🛫 ${start}`,
                     !!scheduled && `⏳ ${scheduled}`,
                     !!due && `📅 ${due}`,
-                    !!start && `🛫 ${start}`,
                     !!done && `✅ ${done}`,
                 ]
                     .filter(Boolean)
                     .join(' ');
 
-                const task = Task.fromLine({
-                    line,
-                    path: '',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    precedingHeader: '',
-                }) as Task;
-                const tasks = [task];
+                const expectedResult: Array<string> = [];
+                if (taskShouldMatch) {
+                    expectedResult.push(line);
+                }
 
-                // Act
-                let filteredTasks = [...tasks];
-                query.filters.forEach((filter) => {
-                    filteredTasks = filteredTasks.filter(filter);
-                });
-
-                // Assert
-                const taskMatched = filteredTasks.length == 1;
-                expect(taskMatched).toEqual(taskShouldMatch);
+                // Act, Assert
+                shouldSupportFiltering([happensFilter], [line], expectedResult);
             },
         );
     });

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -143,42 +143,19 @@ describe('Query', () => {
             // Arrange
             const originalSettings = getSettings();
             updateSettings({ globalFilter: '' });
-            const tasks: Task[] = [
-                Task.fromLine({
-                    line: '- [ ] this does not include the word at all',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    path: '',
-                    precedingHeader: '',
-                }),
-                Task.fromLine({
-                    line: '- [ ] #task this includes the word as a tag',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    path: '',
-                    precedingHeader: '',
-                }),
-                Task.fromLine({
-                    line: '- [ ] #task this does: task',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    path: '',
-                    precedingHeader: '',
-                }),
-            ] as Task[];
-            const input = 'description includes task';
-            const query = new Query({ source: input });
+            const filters: Array<string> = ['description includes task'];
+            const tasks: Array<string> = [
+                '- [ ] this does not include the word at all',
+                '- [ ] #task this includes the word as a tag',
+                '- [ ] #task this does: task',
+            ];
+            const expectedResult: Array<string> = [
+                '- [ ] #task this includes the word as a tag',
+                '- [ ] #task this does: task',
+            ];
 
-            // Act
-            let filteredTasks = [...tasks];
-            query.filters.forEach((filter) => {
-                filteredTasks = filteredTasks.filter(filter);
-            });
-
-            // Assert
-            expect(filteredTasks.length).toEqual(2);
-            expect(filteredTasks[0]).toEqual(tasks[1]);
-            expect(filteredTasks[1]).toEqual(tasks[2]);
+            // Act, Assert
+            shouldSupportFiltering(filters, tasks, expectedResult);
 
             // Cleanup
             updateSettings(originalSettings);

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -106,34 +106,17 @@ describe('Query', () => {
             // Arrange
             const originalSettings = getSettings();
             updateSettings({ globalFilter: '#task' });
-            const tasks: Task[] = [
-                Task.fromLine({
-                    line: '- [ ] #task this does not include the word; only in the global filter',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    path: '',
-                    precedingHeader: '',
-                }),
-                Task.fromLine({
-                    line: '- [ ] #task this does: task',
-                    sectionStart: 0,
-                    sectionIndex: 0,
-                    path: '',
-                    precedingHeader: '',
-                }),
-            ] as Task[];
-            const input = 'description includes task';
-            const query = new Query({ source: input });
+            const filters: Array<string> = ['description includes task'];
+            const tasks: Array<string> = [
+                '- [ ] #task this does not include the word; only in the global filter',
+                '- [ ] #task this does: task',
+            ];
+            const expectedResult: Array<string> = [
+                '- [ ] #task this does: task',
+            ];
 
-            // Act
-            let filteredTasks = [...tasks];
-            query.filters.forEach((filter) => {
-                filteredTasks = filteredTasks.filter(filter);
-            });
-
-            // Assert
-            expect(filteredTasks.length).toEqual(1);
-            expect(filteredTasks[0]).toEqual(tasks[1]);
+            // Act, Assert
+            shouldSupportFiltering(filters, tasks, expectedResult);
 
             // Cleanup
             updateSettings(originalSettings);


### PR DESCRIPTION
3 more tests now use `shouldSupportFiltering(filters, tasks, expectedResult);` to remove some more repetitious code.

