### PR TITLE
Enable viewing of docs in Docker container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ In the simplest case, you can update the existing markdown file and create a pul
 We use [GitHub pages](https://pages.github.com/) for our documentation.
 You can read more about it at their [official documentation](https://docs.github.com/en/pages).
 
+To generate the documentation site on your machine,
+see [docs/README.md](docs/README.md).
+
 For documentation changes to show up at <https://schemar.github.io/obsidian-tasks/> , they must be in the `gh-pages` branch.
 If you want to see your changes available immediately and not only after the next release, you should make your changes on the `gh-pages` branch.
 When you create a PR, it should merge into the `gh-pages` branch as well.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:3.0
+WORKDIR /code
+EXPOSE 4000
+COPY . .
+RUN bundle install
+CMD bundle exec jekyll serve -H 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM ruby:2.7
 WORKDIR /code
 EXPOSE 4000
 COPY . .
+
+WORKDIR /code/docs
 RUN bundle install
 CMD bundle exec jekyll serve -H 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ruby:2.7
 WORKDIR /code
 EXPOSE 4000
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,3 @@ COPY . .
 WORKDIR /code/docs
 RUN bundle install
 CMD bundle exec jekyll serve -H 0.0.0.0
-
-# TODO Add a note in CONTRIBUTING.md linking to docs/README.md
-# TODO Move the following to docs/README.md
-# Make sure Docker is running
-#  cd obsidian-tasks/
-#  docker-compose up
-#   (not docker compose up)
-# Then open http://0.0.0.0:4000/obsidian-tasks/ in your local browser
-# Note that you can edit the files on your local machine and then refresh in the browser

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,12 @@ COPY . .
 WORKDIR /code/docs
 RUN bundle install
 CMD bundle exec jekyll serve -H 0.0.0.0
+
+# TODO Add a note in CONTRIBUTING.md linking to docs/README.md
+# TODO Move the following to docs/README.md
+# Make sure Docker is running
+#  cd obsidian-tasks/
+#  docker-compose up
+#   (not docker compose up)
+# Then open http://0.0.0.0:4000/obsidian-tasks/ in your local browser
+# Note that you can edit the files on your local machine and then refresh in the browser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/code

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,25 @@
 When making significant edits to the documentation, it is helpful to see what
 the published docs will look like. This allows spotting of problems like formatting oddities.
 
+There are two options for seeing what the published pages will look like:
+
+- Docker (recommended)
+- Installing Ruby 2 and Jekyll locally
+
+In both cases, once the Jekyll server is running and you are viewing it in your browser,
+there is a fast feedback cycle of:
+
+1. Edit a markdown page
+2. Wait a few seconds until you see console output like this:
+
+```text
+web_1  |       Regenerating: 1 file(s) changed at 2022-05-07 08:03:54
+web_1  |                     README.md
+web_1  |       Remote Theme: Using theme pmarsceill/just-the-docs
+web_1  |        Jekyll Feed: Generating feed for posts
+```
+3. Reload the page in your browser to see the changes
+
 ## Option 1: Testing via Docker
 
 If you can run docker, this is the easiest way.
@@ -52,11 +71,31 @@ This runs a web server inside Docker that you can view on your own machine.
 Look for the line containing `Server address:` and open that URL in your local browser.
 It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
 
-Note that you can edit the files on your local machine and
+Note that you can now edit the files on your local machine and
 then refresh in the browser a few seconds later.
 
-### Option 2: Testing via local installed Ruby and Jekyll
+## Option 2: Testing via local installed Ruby and Jekyll
 
+### Prerequisites for using installed Jekyll
 
+1. Install ruby. It is important that you use a version 2 of ruby, not version 3, for example 2.7.0.
+1. Install bundler: gem install bundler
+1. Go into the ./docs directory and run `bundle install` to install the dependencies, like jekyll.
 
-`bundle exec jekyll serve`
+You can find more information about these tools, and download links, at
+[Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).
+
+### Seeing the docs via Jekyll
+
+Now every time you want to see the docs locally, run:
+
+```bash
+cd obsidian-tasks/docs
+bundle exec jekyll serve
+```
+
+In the output, look for the line containing `Server address:` and open that URL in your local browser.
+It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
+
+Note that you can now edit the files on your local machine and
+then refresh in the browser a few seconds later.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,24 +12,28 @@
 When making significant edits to the documentation, it is helpful to see what
 the published docs will look like. This allows spotting of problems like formatting oddities.
 
-There are two options for seeing what the published pages will look like:
+### Setup
 
-- Docker (recommended)
-- Installing Ruby 2 and Jekyll locally
+See below for how to set up either of two options for creating the published pages during development:
+
+1. Docker (recommended)
+2. Installed Ruby and Jekyll
+
+### Development cycle
 
 In both cases, once the Jekyll server is running and you are viewing it in your browser,
 there is a fast feedback cycle of:
 
 1. Edit a markdown page
-2. Wait a few seconds until you see console output like this:
-
-```text
-web_1  |       Regenerating: 1 file(s) changed at 2022-05-07 08:03:54
-web_1  |                     README.md
-web_1  |       Remote Theme: Using theme pmarsceill/just-the-docs
-web_1  |        Jekyll Feed: Generating feed for posts
-```
-3. Reload the page in your browser to see the changes
+1. Wait a few seconds until you see console output like this:
+    ```text
+    web_1  |       Regenerating: 1 file(s) changed at 2022-05-07 08:03:54
+    web_1  |                     README.md
+    web_1  |       Remote Theme: Using theme pmarsceill/just-the-docs
+    web_1  |        Jekyll Feed: Generating feed for posts
+    web_1  |                     ...done in 4.02288725 seconds.
+    ```
+1. Reload the page in your browser to see the changes
 
 ## Option 1: Testing via Docker
 
@@ -71,21 +75,24 @@ This runs a web server inside Docker that you can view on your own machine.
 Look for the line containing `Server address:` and open that URL in your local browser.
 It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
 
-Note that you can now edit the files on your local machine and
-then refresh in the browser a few seconds later.
-
 ## Option 2: Testing via local installed Ruby and Jekyll
 
 ### Prerequisites for using installed Jekyll
 
-1. Install ruby. It is important that you use a version 2 of ruby, not version 3, for example 2.7.0.
-1. Install bundler: gem install bundler
-1. Go into the ./docs directory and run `bundle install` to install the dependencies, like jekyll.
+1. Install ruby 2.x.
+    * It is important that you use a version 2 of ruby, not version 3, for example 2.7.0.
+1. Run:
+    ```bash
+    cd obsidian-tasks/
+    gem install bundler
+    cd docs/
+    bundle install
+    ```
 
 You can find more information about these tools, and download links, at
 [Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).
 
-### Seeing the docs via Jekyll
+### Seeing the docs via installed Jekyll
 
 Now every time you want to see the docs locally, run:
 
@@ -96,6 +103,3 @@ bundle exec jekyll serve
 
 In the output, look for the line containing `Server address:` and open that URL in your local browser.
 It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
-
-Note that you can now edit the files on your local machine and
-then refresh in the browser a few seconds later.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-- For background, see ["Updating documentation" in CONTRIBUTING](../CONTRIBUTING.md#updating-documentation)
+- For background, including which branch to work on, see ["Updating documentation" in CONTRIBUTING](../CONTRIBUTING.md#updating-documentation)
 - The documentation is written in Markdown
 - It is converted to HTML via Ruby and Jekyll
   - Important: Ruby 2 is required, for example, Ruby 2.7

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ the published docs will look like. This allows spotting of problems like formatt
 
 See below for how to set up either of two options for creating the published pages during development:
 
-1. Running inside a Docker container (recommended)
-2. Running without Docker
+1. [Running inside a Docker container (recommended)](#option-1-running-inside-a-docker-container)
+2. [Running without Docker](#option-2-running-without-docker)
 
 ### Development cycle
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 ## Overview
 
+- For background, see ["Updating documentation" in CONTRIBUTING](../CONTRIBUTING.md#updating-documentation)
 - The documentation is written in Markdown
 - It is converted to HTML via Ruby and Jekyll
   - Important: Ruby 2 is required, for example, Ruby 2.7

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ the published docs will look like. This allows spotting of problems like formatt
 
 See below for how to set up either of two options for creating the published pages during development:
 
-1. Docker (recommended)
-2. Installed Ruby and Jekyll
+1. Running inside a Docker container (recommended)
+2. Running without Docker
 
 ### Development cycle
 
@@ -35,7 +35,7 @@ there is a fast feedback cycle of:
     ```
 1. Reload the page in your browser to see the changes
 
-## Option 1: Testing via Docker
+## Option 1: Running inside a Docker container
 
 If you can run docker, this is the easiest way.
 
@@ -75,7 +75,9 @@ This runs a web server inside Docker that you can view on your own machine.
 Look for the line containing `Server address:` and open that URL in your local browser.
 It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
 
-## Option 2: Testing via local installed Ruby and Jekyll
+You can stop the service by running `docker-compose down` or by hitting Ctrl+C.
+
+## Option 2: Running without Docker
 
 ### Prerequisites for using installed Jekyll
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,62 @@
 # Documentation for Obsidian Tasks
 
-## Run Locally
+## Overview
+
+- The documentation is written in Markdown
+- It is converted to HTML via Ruby and Jekyll
+  - Important: Ruby 2 is required, for example, Ruby 2.7
+- The published documentation is at <https://schemar.github.io/obsidian-tasks/>
+
+## Test documentation locally with Jekyll
+
+When making significant edits to the documentation, it is helpful to see what
+the published docs will look like. This allows spotting of problems like formatting oddities.
+
+## Option 1: Testing via Docker
+
+If you can run docker, this is the easiest way.
+
+### Prerequisites for using Docker
+
+1. Install Docker
+2. Ensure Docker is running
+
+### Seeing the docs via Docker
+
+Now every time you want to see the docs locally, run:
+
+```bash
+cd obsidian-tasks/
+docker-compose up
+#  (not docker compose up)
+```
+
+You will eventually see output ending something like this:
+
+```text
+web_1  | Configuration file: /code/docs/_config.yml
+web_1  |             Source: /code/docs
+web_1  |        Destination: /code/docs/_site
+web_1  |  Incremental build: disabled. Enable with --incremental
+web_1  |       Generating...
+web_1  |       Remote Theme: Using theme pmarsceill/just-the-docs
+web_1  |        Jekyll Feed: Generating feed for posts
+web_1  |                     done in 4.838 seconds.
+web_1  | /usr/local/bundle/gems/pathutil-0.16.2/lib/pathutil.rb:502: warning: Using the last argument as keyword parameters is deprecated
+web_1  |  Auto-regeneration: enabled for '/code/docs'
+web_1  |     Server address: http://0.0.0.0:4000/obsidian-tasks/
+web_1  |   Server running... press ctrl-c to stop.
+```
+
+This runs a web server inside Docker that you can view on your own machine.
+Look for the line containing `Server address:` and open that URL in your local browser.
+It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
+
+Note that you can edit the files on your local machine and
+then refresh in the browser a few seconds later.
+
+### Option 2: Testing via local installed Ruby and Jekyll
+
+
+
 `bundle exec jekyll serve`


### PR DESCRIPTION
1. Implement testing of documentation locally in a Docker container
2. Document docs-testing process in `docs/README.md`
3. `CONTRIBUTING.md` now links to `docs/README.md`