### PR TITLE
chore: make *.ts and *.js files LF for all operating systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.ts text eol=lf


### PR DESCRIPTION
## Description

Control the line endings for *.ts and *.js files to ensure they are always LF. This will override any local settings and make mergers cleaner as the local IDE will not pick these up as issues nor will lint continually reformat them on fix. 

## Motivation and Context

Reduce noise on different operating systems and changes made by the lint process that will just go away when git does a commit anyway.

## How has this been tested?

Validated in multiple PRs

## Screenshots (if appropriate):

NA

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/schemar/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/schemar/obsidian-tasks/blob/main/CONTRIBUTING.md)