### PR TITLE
Create date filter classes

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -420,7 +420,7 @@ export class Query {
 
     private parseDueFilter({ line }: { line: string }): void {
         const dueDateField = new DueDateField();
-        const { filter, error } = dueDateField.createDueFilterOrErrorMessage(
+        const { filter, error } = dueDateField.createFilterOrErrorMessage(
             line,
             this.dueRegexp,
         );

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -418,7 +418,10 @@ export class Query {
     }
 
     private parseDueFilter({ line }: { line: string }): void {
-        const { filter, error } = this.createDueFilterOrErrorMessage(line);
+        const { filter, error } = this.createDueFilterOrErrorMessage(
+            line,
+            this.dueRegexp,
+        );
 
         if (filter) {
             this._filters.push(filter);
@@ -429,7 +432,7 @@ export class Query {
 
     private createDueFilterOrErrorMessage(
         line: string,
-        instructionRegexp: RegExp = this.dueRegexp,
+        instructionRegexp: RegExp,
     ) {
         let filter;
         let error;

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -395,20 +395,20 @@ export class Query {
 
             let filter;
             if (scheduledMatch[1] === 'before') {
-                filter = (task: Task) =>
-                    task.scheduledDate
-                        ? task.scheduledDate.isBefore(filterDate)
-                        : false;
+                filter = (task: Task) => {
+                    const date = task.scheduledDate;
+                    return date ? date.isBefore(filterDate) : false;
+                };
             } else if (scheduledMatch[1] === 'after') {
-                filter = (task: Task) =>
-                    task.scheduledDate
-                        ? task.scheduledDate.isAfter(filterDate)
-                        : false;
+                filter = (task: Task) => {
+                    const date = task.scheduledDate;
+                    return date ? date.isAfter(filterDate) : false;
+                };
             } else {
-                filter = (task: Task) =>
-                    task.scheduledDate
-                        ? task.scheduledDate.isSame(filterDate)
-                        : false;
+                filter = (task: Task) => {
+                    const date = task.scheduledDate;
+                    return date ? date.isSame(filterDate) : false;
+                };
             }
 
             this._filters.push(filter);

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -157,7 +157,7 @@ export class Query {
                     case this.scheduledRegexp.test(line):
                         this.parseScheduledFilter({ line });
                         break;
-                    case DueDateField.canCreateFilterForLine(line):
+                    case new DueDateField().canCreateFilterForLine(line):
                         this.parseDueFilter({ line });
                         break;
                     case this.doneRegexp.test(line):

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -6,6 +6,8 @@ import { getSettings } from './Settings';
 import { LayoutOptions } from './LayoutOptions';
 import { Sort } from './Sort';
 import { Priority, Status, Task } from './Task';
+
+import type { DateField } from './Query/Filter/DateField';
 import { DoneDateField } from './Query/Filter/DoneDateField';
 import { DueDateField } from './Query/Filter/DueDateField';
 import { ScheduledDateField } from './Query/Filter/ScheduledDateField';
@@ -390,7 +392,7 @@ export class Query {
         this.parseLineWithFieldFilter(line, field);
     }
 
-    private parseLineWithFieldFilter(line: string, field: ScheduledDateField) {
+    private parseLineWithFieldFilter(line: string, field: DateField) {
         const { filter, error } = field.createFilterOrErrorMessage(line);
 
         if (filter) {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -419,11 +419,12 @@ export class Query {
 
     private parseDueFilter({ line }: { line: string }): void {
         let filter;
+        let error;
         const dueMatch = line.match(this.dueRegexp);
         if (dueMatch !== null) {
             const filterDate = Query.parseDate(dueMatch[2]);
             if (!filterDate.isValid()) {
-                this._error = 'do not understand due date';
+                error = 'do not understand due date';
             } else {
                 if (dueMatch[1] === 'before') {
                     filter = (task: Task) =>
@@ -439,11 +440,13 @@ export class Query {
                 }
             }
         } else {
-            this._error = 'do not understand query filter (due date)';
+            error = 'do not understand query filter (due date)';
         }
 
         if (filter) {
             this._filters.push(filter);
+        } else {
+            this._error = error;
         }
     }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -57,7 +57,6 @@ export class Query {
 
     private readonly noDueString = 'no due date';
     private readonly hasDueString = 'has due date';
-    private readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
     private readonly doneString = 'done';
     private readonly notDoneString = 'not done';
@@ -420,10 +419,7 @@ export class Query {
 
     private parseDueFilter({ line }: { line: string }): void {
         const dueDateField = new DueDateField();
-        const { filter, error } = dueDateField.createFilterOrErrorMessage(
-            line,
-            this.dueRegexp,
-        );
+        const { filter, error } = dueDateField.createFilterOrErrorMessage(line);
 
         if (filter) {
             this._filters.push(filter);

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -418,13 +418,13 @@ export class Query {
     }
 
     private parseDueFilter({ line }: { line: string }): void {
+        let filter;
         const dueMatch = line.match(this.dueRegexp);
         if (dueMatch !== null) {
             const filterDate = Query.parseDate(dueMatch[2]);
             if (!filterDate.isValid()) {
                 this._error = 'do not understand due date';
             } else {
-                let filter;
                 if (dueMatch[1] === 'before') {
                     filter = (task: Task) =>
                         task.dueDate
@@ -437,11 +437,13 @@ export class Query {
                     filter = (task: Task) =>
                         task.dueDate ? task.dueDate.isSame(filterDate) : false;
                 }
-
-                this._filters.push(filter);
             }
         } else {
             this._error = 'do not understand query filter (due date)';
+        }
+
+        if (filter) {
+            this._filters.push(filter);
         }
     }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -7,7 +7,7 @@ import { LayoutOptions } from './LayoutOptions';
 import { Sort } from './Sort';
 import { Priority, Status, Task } from './Task';
 
-import type { DateField } from './Query/Filter/DateField';
+import type { Field } from './Query/Filter/Field';
 import { DoneDateField } from './Query/Filter/DoneDateField';
 import { DueDateField } from './Query/Filter/DueDateField';
 import { ScheduledDateField } from './Query/Filter/ScheduledDateField';
@@ -356,7 +356,7 @@ export class Query {
         }
     }
 
-    private parseFilter(line: string, field: DateField) {
+    private parseFilter(line: string, field: Field) {
         if (field.canCreateFilterForLine(line)) {
             const { filter, error } = field.createFilterOrErrorMessage(line);
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -156,8 +156,7 @@ export class Query {
                     case this.startRegexp.test(line):
                         this.parseStartFilter({ line });
                         break;
-                    case new ScheduledDateField().canCreateFilterForLine(line):
-                        this.parseScheduledFilter({ line });
+                    case this.parseFilter(line, new ScheduledDateField()):
                         break;
                     case this.parseFilter(line, new DueDateField()):
                         break;
@@ -382,21 +381,6 @@ export class Query {
             this._filters.push(filter);
         } else {
             this._error = 'do not understand query filter (start date)';
-        }
-    }
-
-    private parseScheduledFilter({ line }: { line: string }): void {
-        const field = new ScheduledDateField();
-        this.parseLineWithFieldFilter(line, field);
-    }
-
-    private parseLineWithFieldFilter(line: string, field: DateField) {
-        const { filter, error } = field.createFilterOrErrorMessage(line);
-
-        if (filter) {
-            this._filters.push(filter);
-        } else {
-            this._error = error;
         }
     }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -423,22 +423,23 @@ export class Query {
             const filterDate = Query.parseDate(dueMatch[2]);
             if (!filterDate.isValid()) {
                 this._error = 'do not understand due date';
-                return;
-            }
-
-            let filter;
-            if (dueMatch[1] === 'before') {
-                filter = (task: Task) =>
-                    task.dueDate ? task.dueDate.isBefore(filterDate) : false;
-            } else if (dueMatch[1] === 'after') {
-                filter = (task: Task) =>
-                    task.dueDate ? task.dueDate.isAfter(filterDate) : false;
             } else {
-                filter = (task: Task) =>
-                    task.dueDate ? task.dueDate.isSame(filterDate) : false;
-            }
+                let filter;
+                if (dueMatch[1] === 'before') {
+                    filter = (task: Task) =>
+                        task.dueDate
+                            ? task.dueDate.isBefore(filterDate)
+                            : false;
+                } else if (dueMatch[1] === 'after') {
+                    filter = (task: Task) =>
+                        task.dueDate ? task.dueDate.isAfter(filterDate) : false;
+                } else {
+                    filter = (task: Task) =>
+                        task.dueDate ? task.dueDate.isSame(filterDate) : false;
+                }
 
-            this._filters.push(filter);
+                this._filters.push(filter);
+            }
         } else {
             this._error = 'do not understand query filter (due date)';
         }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -159,8 +159,7 @@ export class Query {
                     case new ScheduledDateField().canCreateFilterForLine(line):
                         this.parseScheduledFilter({ line });
                         break;
-                    case new DueDateField().canCreateFilterForLine(line):
-                        this.parseDueFilter({ line });
+                    case this.parseFilter(line, new DueDateField()):
                         break;
                     case this.parseFilter(line, new DoneDateField()):
                         break;
@@ -392,17 +391,6 @@ export class Query {
     }
 
     private parseLineWithFieldFilter(line: string, field: DateField) {
-        const { filter, error } = field.createFilterOrErrorMessage(line);
-
-        if (filter) {
-            this._filters.push(filter);
-        } else {
-            this._error = error;
-        }
-    }
-
-    private parseDueFilter({ line }: { line: string }): void {
-        const field = new DueDateField();
         const { filter, error } = field.createFilterOrErrorMessage(line);
 
         if (filter) {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -418,6 +418,16 @@ export class Query {
     }
 
     private parseDueFilter({ line }: { line: string }): void {
+        const { filter, error } = this.createDueFilterOrErrorMessage(line);
+
+        if (filter) {
+            this._filters.push(filter);
+        } else {
+            this._error = error;
+        }
+    }
+
+    private createDueFilterOrErrorMessage(line: string) {
         let filter;
         let error;
         const dueMatch = line.match(this.dueRegexp);
@@ -442,12 +452,7 @@ export class Query {
         } else {
             error = 'do not understand query filter (due date)';
         }
-
-        if (filter) {
-            this._filters.push(filter);
-        } else {
-            this._error = error;
-        }
+        return { filter: filter, error };
     }
 
     private parseDoneFilter({ line }: { line: string }): void {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -11,6 +11,7 @@ import type { DateField } from './Query/Filter/DateField';
 import { DoneDateField } from './Query/Filter/DoneDateField';
 import { DueDateField } from './Query/Filter/DueDateField';
 import { ScheduledDateField } from './Query/Filter/ScheduledDateField';
+import { StartDateField } from './Query/Filter/StartDateField';
 
 export type SortingProperty =
     | 'urgency'
@@ -53,7 +54,6 @@ export class Query {
 
     private readonly noStartString = 'no start date';
     private readonly hasStartString = 'has start date';
-    private readonly startRegexp = /^starts (before|after|on)? ?(.*)/;
 
     private readonly noScheduledString = 'no scheduled date';
     private readonly hasScheduledString = 'has scheduled date';
@@ -153,8 +153,7 @@ export class Query {
                     case this.happensRegexp.test(line):
                         this.parseHappensFilter({ line });
                         break;
-                    case this.startRegexp.test(line):
-                        this.parseStartFilter({ line });
+                    case this.parseFilter(line, new StartDateField()):
                         break;
                     case this.parseFilter(line, new ScheduledDateField()):
                         break;
@@ -354,33 +353,6 @@ export class Query {
             this._filters.push(filter);
         } else {
             this._error = 'do not understand query filter (happens date)';
-        }
-    }
-
-    private parseStartFilter({ line }: { line: string }): void {
-        const startMatch = line.match(this.startRegexp);
-        if (startMatch !== null) {
-            const filterDate = Query.parseDate(startMatch[2]);
-            if (!filterDate.isValid()) {
-                this._error = 'do not understand start date';
-                return;
-            }
-
-            let filter;
-            if (startMatch[1] === 'before') {
-                filter = (task: Task) =>
-                    task.startDate ? task.startDate.isBefore(filterDate) : true;
-            } else if (startMatch[1] === 'after') {
-                filter = (task: Task) =>
-                    task.startDate ? task.startDate.isAfter(filterDate) : true;
-            } else {
-                filter = (task: Task) =>
-                    task.startDate ? task.startDate.isSame(filterDate) : true;
-            }
-
-            this._filters.push(filter);
-        } else {
-            this._error = 'do not understand query filter (start date)';
         }
     }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -427,10 +427,13 @@ export class Query {
         }
     }
 
-    private createDueFilterOrErrorMessage(line: string) {
+    private createDueFilterOrErrorMessage(
+        line: string,
+        instructionRegexp: RegExp = this.dueRegexp,
+    ) {
         let filter;
         let error;
-        const dueMatch = line.match(this.dueRegexp);
+        const dueMatch = line.match(instructionRegexp);
         if (dueMatch !== null) {
             const filterDate = Query.parseDate(dueMatch[2]);
             if (!filterDate.isValid()) {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -387,6 +387,10 @@ export class Query {
 
     private parseScheduledFilter({ line }: { line: string }): void {
         const field = new ScheduledDateField();
+        this.parseLineWithFieldFilter(line, field);
+    }
+
+    private parseLineWithFieldFilter(line: string, field: ScheduledDateField) {
         const { filter, error } = field.createFilterOrErrorMessage(line);
 
         if (filter) {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -624,7 +624,7 @@ export class Query {
         }
     }
 
-    static parseDate(input: string): moment.Moment {
+    public static parseDate(input: string): moment.Moment {
         // Using start of day to correctly match on comparison with other dates (like equality).
         return window.moment(chrono.parseDate(input)).startOf('day');
     }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -158,7 +158,7 @@ export class Query {
                     case this.scheduledRegexp.test(line):
                         this.parseScheduledFilter({ line });
                         break;
-                    case this.dueRegexp.test(line):
+                    case DueDateField.canCreateFilterForLine(line):
                         this.parseDueFilter({ line });
                         break;
                     case this.doneRegexp.test(line):

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -162,8 +162,7 @@ export class Query {
                     case new DueDateField().canCreateFilterForLine(line):
                         this.parseDueFilter({ line });
                         break;
-                    case new DoneDateField().canCreateFilterForLine(line):
-                        this.parseDoneFilter({ line });
+                    case this.parseFilter(line, new DoneDateField()):
                         break;
                     case this.pathRegexp.test(line):
                         this.parsePathFilter({ line });
@@ -413,14 +412,18 @@ export class Query {
         }
     }
 
-    private parseDoneFilter({ line }: { line: string }): void {
-        const field = new DoneDateField();
-        const { filter, error } = field.createFilterOrErrorMessage(line);
+    private parseFilter(line: string, field: DateField) {
+        if (field.canCreateFilterForLine(line)) {
+            const { filter, error } = field.createFilterOrErrorMessage(line);
 
-        if (filter) {
-            this._filters.push(filter);
+            if (filter) {
+                this._filters.push(filter);
+            } else {
+                this._error = error;
+            }
+            return true;
         } else {
-            this._error = error;
+            return false;
         }
     }
 

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -4,6 +4,11 @@ import type { Task } from '../../Task';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
+/**
+ * DateField is an abstract base class to help implement
+ * all the filter instructions that act on a single type of date
+ * value, such as the done date.
+ */
 export abstract class DateField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
@@ -46,7 +51,19 @@ export abstract class DateField extends Field {
         return result;
     }
 
+    /**
+     * Return the task's value for this date field, if any.
+     * @param task - a Task object
+     * @protected
+     */
     protected abstract date(task: Task): Moment | null;
 
+    /**
+     * Determine whether a task that does not have the particular date value
+     * should be treated as a match. For example, 'starts' searches match all tasks
+     * that have no start date, which behaves differently from 'due', 'done' and
+     * 'scheduled' searches.
+     * @protected
+     */
     protected abstract filterResultIfFieldMissing(): boolean;
 }

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -6,30 +6,30 @@ import { FilterOrErrorMessage } from './Filter';
 
 export abstract class DateField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        let filter;
-        let error;
+        const result = new FilterOrErrorMessage();
         const match = line.match(this.filterRegexp());
         if (match !== null) {
             const filterDate = Query.parseDate(match[2]);
             if (!filterDate.isValid()) {
-                error = 'do not understand ' + this.fieldName() + ' date';
+                result.error =
+                    'do not understand ' + this.fieldName() + ' date';
             } else {
                 if (match[1] === 'before') {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         const date = this.date(task);
                         return date
                             ? date.isBefore(filterDate)
                             : this.filterResultIfFieldMissing();
                     };
                 } else if (match[1] === 'after') {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         const date = this.date(task);
                         return date
                             ? date.isAfter(filterDate)
                             : this.filterResultIfFieldMissing();
                     };
                 } else {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         const date = this.date(task);
                         return date
                             ? date.isSame(filterDate)
@@ -38,14 +38,11 @@ export abstract class DateField extends Field {
                 }
             }
         } else {
-            error =
+            result.error =
                 'do not understand query filter (' +
                 this.fieldName() +
                 ' date)';
         }
-        const result = new FilterOrErrorMessage();
-        result.filter = filter;
-        result.error = error;
         return result;
     }
 

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -1,0 +1,48 @@
+import type { Moment } from 'moment';
+import { Query } from '../../Query';
+import type { Task } from '../../Task';
+
+export abstract class DateField {
+    public abstract canCreateFilterForLine(line: string): boolean;
+
+    public createFilterOrErrorMessage(line: string) {
+        let filter;
+        let error;
+        const match = line.match(this.filterRegexp());
+        if (match !== null) {
+            const filterDate = Query.parseDate(match[2]);
+            if (!filterDate.isValid()) {
+                error = 'do not understand ' + this.fieldName() + ' date';
+            } else {
+                if (match[1] === 'before') {
+                    filter = (task: Task) => {
+                        const date = this.date(task);
+                        return date ? date.isBefore(filterDate) : false;
+                    };
+                } else if (match[1] === 'after') {
+                    filter = (task: Task) => {
+                        const date = this.date(task);
+                        return date ? date.isAfter(filterDate) : false;
+                    };
+                } else {
+                    filter = (task: Task) => {
+                        const date = this.date(task);
+                        return date ? date.isSame(filterDate) : false;
+                    };
+                }
+            }
+        } else {
+            error =
+                'do not understand query filter (' +
+                this.fieldName() +
+                ' date)';
+        }
+        return { filter: filter, error };
+    }
+
+    protected abstract filterRegexp(): RegExp;
+
+    protected abstract fieldName(): string;
+
+    protected abstract date(task: Task): Moment | null;
+}

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -1,8 +1,9 @@
 import type { Moment } from 'moment';
 import { Query } from '../../Query';
 import type { Task } from '../../Task';
+import { Field } from './Field';
 
-export abstract class DateField {
+export abstract class DateField extends Field {
     public canCreateFilterForLine(line: string): boolean {
         return this.filterRegexp().test(line);
     }

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -2,13 +2,14 @@ import type { Moment } from 'moment';
 import { Query } from '../../Query';
 import type { Task } from '../../Task';
 import { Field } from './Field';
+import { FilterOrErrorMessage } from './Filter';
 
 export abstract class DateField extends Field {
     public canCreateFilterForLine(line: string): boolean {
         return this.filterRegexp().test(line);
     }
 
-    public createFilterOrErrorMessage(line: string) {
+    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         let filter;
         let error;
         const match = line.match(this.filterRegexp());
@@ -46,7 +47,10 @@ export abstract class DateField extends Field {
                 this.fieldName() +
                 ' date)';
         }
-        return { filter: filter, error };
+        const result = new FilterOrErrorMessage();
+        result.filter = filter;
+        result.error = error;
+        return result;
     }
 
     protected abstract date(task: Task): Moment | null;

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -3,7 +3,9 @@ import { Query } from '../../Query';
 import type { Task } from '../../Task';
 
 export abstract class DateField {
-    public abstract canCreateFilterForLine(line: string): boolean;
+    public canCreateFilterForLine(line: string): boolean {
+        return this.filterRegexp().test(line);
+    }
 
     public createFilterOrErrorMessage(line: string) {
         let filter;

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -19,17 +19,23 @@ export abstract class DateField {
                 if (match[1] === 'before') {
                     filter = (task: Task) => {
                         const date = this.date(task);
-                        return date ? date.isBefore(filterDate) : false;
+                        return date
+                            ? date.isBefore(filterDate)
+                            : this.filterResultIfFieldMissing();
                     };
                 } else if (match[1] === 'after') {
                     filter = (task: Task) => {
                         const date = this.date(task);
-                        return date ? date.isAfter(filterDate) : false;
+                        return date
+                            ? date.isAfter(filterDate)
+                            : this.filterResultIfFieldMissing();
                     };
                 } else {
                     filter = (task: Task) => {
                         const date = this.date(task);
-                        return date ? date.isSame(filterDate) : false;
+                        return date
+                            ? date.isSame(filterDate)
+                            : this.filterResultIfFieldMissing();
                     };
                 }
             }
@@ -47,4 +53,6 @@ export abstract class DateField {
     protected abstract fieldName(): string;
 
     protected abstract date(task: Task): Moment | null;
+
+    protected abstract filterResultIfFieldMissing(): boolean;
 }

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -5,10 +5,6 @@ import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
 export abstract class DateField extends Field {
-    public canCreateFilterForLine(line: string): boolean {
-        return this.filterRegexp().test(line);
-    }
-
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         let filter;
         let error;

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -49,10 +49,6 @@ export abstract class DateField extends Field {
         return { filter: filter, error };
     }
 
-    protected abstract filterRegexp(): RegExp;
-
-    protected abstract fieldName(): string;
-
     protected abstract date(task: Task): Moment | null;
 
     protected abstract filterResultIfFieldMissing(): boolean;

--- a/src/Query/Filter/DoneDateField.ts
+++ b/src/Query/Filter/DoneDateField.ts
@@ -2,6 +2,9 @@ import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { DateField } from './DateField';
 
+/**
+ * Support the 'done' search instruction.
+ */
 export class DoneDateField extends DateField {
     private static readonly doneRegexp = /^done (before|after|on)? ?(.*)/;
 

--- a/src/Query/Filter/DoneDateField.ts
+++ b/src/Query/Filter/DoneDateField.ts
@@ -1,0 +1,17 @@
+import type { Moment } from 'moment';
+import type { Task } from '../../Task';
+import { DateField } from './DateField';
+
+export class DoneDateField extends DateField {
+    private static readonly doneRegexp = /^done (before|after|on)? ?(.*)/;
+
+    protected filterRegexp(): RegExp {
+        return DoneDateField.doneRegexp;
+    }
+    protected fieldName(): string {
+        return 'done';
+    }
+    protected date(task: Task): Moment | null {
+        return task.doneDate;
+    }
+}

--- a/src/Query/Filter/DoneDateField.ts
+++ b/src/Query/Filter/DoneDateField.ts
@@ -14,4 +14,7 @@ export class DoneDateField extends DateField {
     protected date(task: Task): Moment | null {
         return task.doneDate;
     }
+    protected filterResultIfFieldMissing() {
+        return false;
+    }
 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -1,57 +1,20 @@
 import type { Moment } from 'moment';
 import type { Task } from '../../Task';
-import { Query } from '../../Query';
+import { DateField } from './DateField';
 
-export class DueDateField {
+export class DueDateField extends DateField {
     private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
     public canCreateFilterForLine(line: string): boolean {
         return this.filterRegexp().test(line);
     }
-    public createFilterOrErrorMessage(line: string) {
-        let filter;
-        let error;
-        const match = line.match(this.filterRegexp());
-        if (match !== null) {
-            const filterDate = Query.parseDate(match[2]);
-            if (!filterDate.isValid()) {
-                error = 'do not understand ' + this.fieldName() + ' date';
-            } else {
-                if (match[1] === 'before') {
-                    filter = (task: Task) => {
-                        const date = this.date(task);
-                        return date ? date.isBefore(filterDate) : false;
-                    };
-                } else if (match[1] === 'after') {
-                    filter = (task: Task) => {
-                        const date = this.date(task);
-                        return date ? date.isAfter(filterDate) : false;
-                    };
-                } else {
-                    filter = (task: Task) => {
-                        const date = this.date(task);
-                        return date ? date.isSame(filterDate) : false;
-                    };
-                }
-            }
-        } else {
-            error =
-                'do not understand query filter (' +
-                this.fieldName() +
-                ' date)';
-        }
-        return { filter: filter, error };
-    }
-
-    private filterRegexp(): RegExp {
+    protected filterRegexp(): RegExp {
         return DueDateField.dueRegexp;
     }
-
-    private fieldName(): string {
+    protected fieldName(): string {
         return 'due';
     }
-
-    private date(task: Task): Moment | null {
+    protected date(task: Task): Moment | null {
         return task.dueDate;
     }
 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -7,10 +7,10 @@ export class DueDateField {
     public static canCreateFilterForLine(line: string) {
         return DueDateField.dueRegexp.test(line);
     }
-    public createFilterOrErrorMessage(line: string, instructionRegexp: RegExp) {
+    public createFilterOrErrorMessage(line: string) {
         let filter;
         let error;
-        const match = line.match(instructionRegexp);
+        const match = line.match(DueDateField.dueRegexp);
         if (match !== null) {
             const filterDate = Query.parseDate(match[2]);
             if (!filterDate.isValid()) {

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -2,6 +2,11 @@ import type { Task } from '../../Task';
 import { Query } from '../../Query';
 
 export class DueDateField {
+    private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
+
+    public static canCreateFilterForLine(line: string) {
+        return DueDateField.dueRegexp.test(line);
+    }
     public createFilterOrErrorMessage(line: string, instructionRegexp: RegExp) {
         let filter;
         let error;

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -5,9 +5,6 @@ import { DateField } from './DateField';
 export class DueDateField extends DateField {
     private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
-    public canCreateFilterForLine(line: string): boolean {
-        return this.filterRegexp().test(line);
-    }
     protected filterRegexp(): RegExp {
         return DueDateField.dueRegexp;
     }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -14,4 +14,7 @@ export class DueDateField extends DateField {
     protected date(task: Task): Moment | null {
         return task.dueDate;
     }
+    protected filterResultIfFieldMissing() {
+        return false;
+    }
 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -8,18 +8,18 @@ export class DueDateField {
     ) {
         let filter;
         let error;
-        const dueMatch = line.match(instructionRegexp);
-        if (dueMatch !== null) {
-            const filterDate = Query.parseDate(dueMatch[2]);
+        const match = line.match(instructionRegexp);
+        if (match !== null) {
+            const filterDate = Query.parseDate(match[2]);
             if (!filterDate.isValid()) {
                 error = 'do not understand due date';
             } else {
-                if (dueMatch[1] === 'before') {
+                if (match[1] === 'before') {
                     filter = (task: Task) =>
                         task.dueDate
                             ? task.dueDate.isBefore(filterDate)
                             : false;
-                } else if (dueMatch[1] === 'after') {
+                } else if (match[1] === 'after') {
                     filter = (task: Task) =>
                         task.dueDate ? task.dueDate.isAfter(filterDate) : false;
                 } else {

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -10,7 +10,7 @@ export class DueDateField {
     public createFilterOrErrorMessage(line: string) {
         let filter;
         let error;
-        const match = line.match(DueDateField.dueRegexp);
+        const match = line.match(this.filterRegexp());
         if (match !== null) {
             const filterDate = Query.parseDate(match[2]);
             if (!filterDate.isValid()) {
@@ -40,6 +40,10 @@ export class DueDateField {
                 ' date)';
         }
         return { filter: filter, error };
+    }
+
+    private filterRegexp() {
+        return DueDateField.dueRegexp;
     }
 
     private fieldName() {

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -2,10 +2,7 @@ import type { Task } from '../../Task';
 import { Query } from '../../Query';
 
 export class DueDateField {
-    public createDueFilterOrErrorMessage(
-        line: string,
-        instructionRegexp: RegExp,
-    ) {
+    public createFilterOrErrorMessage(line: string, instructionRegexp: RegExp) {
         let filter;
         let error;
         const match = line.match(instructionRegexp);

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -16,7 +16,7 @@ export class DueDateField {
             } else {
                 if (match[1] === 'before') {
                     filter = (task: Task) => {
-                        const date = task.dueDate;
+                        const date = this.date(task);
                         return date ? date.isBefore(filterDate) : false;
                     };
                 } else if (match[1] === 'after') {
@@ -35,5 +35,9 @@ export class DueDateField {
             error = 'do not understand query filter (due date)';
         }
         return { filter: filter, error };
+    }
+
+    private date(task: Task) {
+        return task.dueDate;
     }
 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -2,6 +2,9 @@ import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { DateField } from './DateField';
 
+/**
+ * Support the 'due' search instruction.
+ */
 export class DueDateField extends DateField {
     private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -1,0 +1,32 @@
+import type { Task } from '../../Task';
+import { Query } from '../../Query';
+
+export class DueDateField {
+    createDueFilterOrErrorMessage(line: string, instructionRegexp: RegExp) {
+        let filter;
+        let error;
+        const dueMatch = line.match(instructionRegexp);
+        if (dueMatch !== null) {
+            const filterDate = Query.parseDate(dueMatch[2]);
+            if (!filterDate.isValid()) {
+                error = 'do not understand due date';
+            } else {
+                if (dueMatch[1] === 'before') {
+                    filter = (task: Task) =>
+                        task.dueDate
+                            ? task.dueDate.isBefore(filterDate)
+                            : false;
+                } else if (dueMatch[1] === 'after') {
+                    filter = (task: Task) =>
+                        task.dueDate ? task.dueDate.isAfter(filterDate) : false;
+                } else {
+                    filter = (task: Task) =>
+                        task.dueDate ? task.dueDate.isSame(filterDate) : false;
+                }
+            }
+        } else {
+            error = 'do not understand query filter (due date)';
+        }
+        return { filter: filter, error };
+    }
+}

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -12,7 +12,7 @@ export class DueDateField {
         if (match !== null) {
             const filterDate = Query.parseDate(match[2]);
             if (!filterDate.isValid()) {
-                error = 'do not understand due date';
+                error = 'do not understand ' + this.fieldName() + ' date';
             } else {
                 if (match[1] === 'before') {
                     filter = (task: Task) => {
@@ -32,9 +32,16 @@ export class DueDateField {
                 }
             }
         } else {
-            error = 'do not understand query filter (due date)';
+            error =
+                'do not understand query filter (' +
+                this.fieldName() +
+                ' date)';
         }
         return { filter: filter, error };
+    }
+
+    private fieldName() {
+        return 'due';
     }
 
     private date(task: Task) {

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -21,12 +21,12 @@ export class DueDateField {
                     };
                 } else if (match[1] === 'after') {
                     filter = (task: Task) => {
-                        const date = task.dueDate;
+                        const date = this.date(task);
                         return date ? date.isAfter(filterDate) : false;
                     };
                 } else {
                     filter = (task: Task) => {
-                        const date = task.dueDate;
+                        const date = this.date(task);
                         return date ? date.isSame(filterDate) : false;
                     };
                 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -2,7 +2,10 @@ import type { Task } from '../../Task';
 import { Query } from '../../Query';
 
 export class DueDateField {
-    createDueFilterOrErrorMessage(line: string, instructionRegexp: RegExp) {
+    public createDueFilterOrErrorMessage(
+        line: string,
+        instructionRegexp: RegExp,
+    ) {
         let filter;
         let error;
         const dueMatch = line.match(instructionRegexp);

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -15,16 +15,20 @@ export class DueDateField {
                 error = 'do not understand due date';
             } else {
                 if (match[1] === 'before') {
-                    filter = (task: Task) =>
-                        task.dueDate
-                            ? task.dueDate.isBefore(filterDate)
-                            : false;
+                    filter = (task: Task) => {
+                        const date = task.dueDate;
+                        return date ? date.isBefore(filterDate) : false;
+                    };
                 } else if (match[1] === 'after') {
-                    filter = (task: Task) =>
-                        task.dueDate ? task.dueDate.isAfter(filterDate) : false;
+                    filter = (task: Task) => {
+                        const date = task.dueDate;
+                        return date ? date.isAfter(filterDate) : false;
+                    };
                 } else {
-                    filter = (task: Task) =>
-                        task.dueDate ? task.dueDate.isSame(filterDate) : false;
+                    filter = (task: Task) => {
+                        const date = task.dueDate;
+                        return date ? date.isSame(filterDate) : false;
+                    };
                 }
             }
         } else {

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -4,8 +4,8 @@ import { Query } from '../../Query';
 export class DueDateField {
     private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
-    public static canCreateFilterForLine(line: string) {
-        return DueDateField.dueRegexp.test(line);
+    public canCreateFilterForLine(line: string) {
+        return this.filterRegexp().test(line);
     }
     public createFilterOrErrorMessage(line: string) {
         let filter;

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -1,10 +1,11 @@
+import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { Query } from '../../Query';
 
 export class DueDateField {
     private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;
 
-    public canCreateFilterForLine(line: string) {
+    public canCreateFilterForLine(line: string): boolean {
         return this.filterRegexp().test(line);
     }
     public createFilterOrErrorMessage(line: string) {
@@ -42,15 +43,15 @@ export class DueDateField {
         return { filter: filter, error };
     }
 
-    private filterRegexp() {
+    private filterRegexp(): RegExp {
         return DueDateField.dueRegexp;
     }
 
-    private fieldName() {
+    private fieldName(): string {
         return 'due';
     }
 
-    private date(task: Task) {
+    private date(task: Task): Moment | null {
         return task.dueDate;
     }
 }

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -1,7 +1,9 @@
 import type { FilterOrErrorMessage } from './Filter';
 
 export abstract class Field {
-    public abstract canCreateFilterForLine(line: string): boolean;
+    public canCreateFilterForLine(line: string): boolean {
+        return this.filterRegexp().test(line);
+    }
 
     public abstract createFilterOrErrorMessage(
         line: string,

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -1,10 +1,11 @@
+import type { FilterOrErrorMessage } from './Filter';
+
 export abstract class Field {
     public abstract canCreateFilterForLine(line: string): boolean;
 
-    public abstract createFilterOrErrorMessage(line: string): {
-        filter: any;
-        error: any;
-    };
+    public abstract createFilterOrErrorMessage(
+        line: string,
+    ): FilterOrErrorMessage;
 
     protected abstract filterRegexp(): RegExp;
 

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -1,0 +1,12 @@
+export abstract class Field {
+    public abstract canCreateFilterForLine(line: string): boolean;
+
+    public abstract createFilterOrErrorMessage(line: string): {
+        filter: any;
+        error: any;
+    };
+
+    protected abstract filterRegexp(): RegExp;
+
+    protected abstract fieldName(): string;
+}

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -1,15 +1,51 @@
 import type { FilterOrErrorMessage } from './Filter';
 
+/**
+ * Field is an abstract base class for each type of filter instruction.
+ *
+ * For example, derived class StartDateField implements the parsing
+ * of 'starts' instructions.
+ *
+ * The name 'Field' may seem confusing, as it might currently be
+ * expected to have the word 'Filter' in the class name.
+ *
+ * Current thinking is that it may well evolve later to also implement
+ * the presence and absence searches as well
+ * (such 'no start date' and 'has start date').
+ */
 export abstract class Field {
+    /**
+     * Returns true if the class can parse the given instruction line.
+     *
+     * Current implementation simply checks whether the line matches
+     * this.filterRegexp().
+     * @param line - A line from a ```tasks``` block.
+     */
     public canCreateFilterForLine(line: string): boolean {
         return this.filterRegexp().test(line);
     }
 
+    /**
+     * Parse the line, and return either a Filter function or an error string,
+     * which are both wrapped in a FilterOrErrorMessage object.
+     * @param line - A line from a ```tasks``` block.
+     */
     public abstract createFilterOrErrorMessage(
         line: string,
     ): FilterOrErrorMessage;
 
+    /**
+     * Return a regular expression that will match a correctly-formed
+     * instruction line for filtering Tasks by inspecting the value of this field.
+     * @protected
+     */
     protected abstract filterRegexp(): RegExp;
 
+    /**
+     * Return the name of this field, to be used in error messages.
+     * This usually matches the instruction name, but does not always
+     * (see start and starts).
+     * @protected
+     */
     protected abstract fieldName(): string;
 }

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -8,7 +8,7 @@ type Filter = (task: Task) => boolean;
 
 /**
  * A class which stores one of:
- * - A filter
+ * - A Filter
  * - An error message
  *
  * This is really currently a convenience for returning date from

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -1,7 +1,24 @@
 import type { Task } from '../../Task';
 
+/**
+ * A filtering function, that takes a Task object and returns
+ * whether it matches a particular filtering instruction.
+ */
 type Filter = (task: Task) => boolean;
 
+/**
+ * A class which stores one of:
+ * - A filter
+ * - An error message
+ *
+ * This is really currently a convenience for returning date from
+ * Field.createFilterOrErrorMessage() and derived classes.
+ *
+ * Later, it may gain helper functions for constructing parser error messages,
+ * as currently these are created by some rather repetitious code, and also
+ * there is scope for making these messages more informative (including the
+ * problem line, and perhaps listing allowed options).
+ */
 export class FilterOrErrorMessage {
     filter: Filter | undefined;
     error: string | undefined;

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -1,0 +1,8 @@
+import type { Task } from '../../Task';
+
+type Filter = (task: Task) => boolean;
+
+export class FilterOrErrorMessage {
+    filter: Filter | undefined;
+    error: string | undefined;
+}

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -6,10 +6,6 @@ import { FilterOrErrorMessage } from './Filter';
 export class HappensDateField extends Field {
     private static readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
 
-    canCreateFilterForLine(line: string): boolean {
-        return this.filterRegexp().test(line);
-    }
-
     createFilterOrErrorMessage(line: string): { filter: any; error: any } {
         let filter;
         let error;

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -3,6 +3,10 @@ import { Query } from '../../Query';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
+/**
+ * Support the 'happens' search instruction, which searches all of
+ * start, scheduled and due dates.
+ */
 export class HappensDateField extends Field {
     private static readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
 

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -6,10 +6,7 @@ import { FilterOrErrorMessage } from './Filter';
 export class HappensDateField extends Field {
     private static readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
 
-    public createFilterOrErrorMessage(line: string): {
-        filter: any;
-        error: any;
-    } {
+    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
         const happensMatch = line.match(this.filterRegexp());
         if (happensMatch !== null) {

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -1,0 +1,64 @@
+import type { Task } from '../../Task';
+import { Query } from '../../Query';
+import { Field } from './Field';
+import { FilterOrErrorMessage } from './Filter';
+
+export class HappensDateField extends Field {
+    private static readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
+
+    canCreateFilterForLine(line: string): boolean {
+        return this.filterRegexp().test(line);
+    }
+
+    createFilterOrErrorMessage(line: string): { filter: any; error: any } {
+        let filter;
+        let error;
+        const happensMatch = line.match(this.filterRegexp());
+        if (happensMatch !== null) {
+            const filterDate = Query.parseDate(happensMatch[2]);
+            if (!filterDate.isValid()) {
+                error = 'do not understand happens date';
+            } else {
+                if (happensMatch[1] === 'before') {
+                    filter = (task: Task) => {
+                        return Array.of(
+                            task.startDate,
+                            task.scheduledDate,
+                            task.dueDate,
+                        ).some((date) => date && date.isBefore(filterDate));
+                    };
+                } else if (happensMatch[1] === 'after') {
+                    filter = (task: Task) => {
+                        return Array.of(
+                            task.startDate,
+                            task.scheduledDate,
+                            task.dueDate,
+                        ).some((date) => date && date.isAfter(filterDate));
+                    };
+                } else {
+                    filter = (task: Task) => {
+                        return Array.of(
+                            task.startDate,
+                            task.scheduledDate,
+                            task.dueDate,
+                        ).some((date) => date && date.isSame(filterDate));
+                    };
+                }
+            }
+        } else {
+            error = 'do not understand query filter (happens date)';
+        }
+        const result = new FilterOrErrorMessage();
+        result.filter = filter;
+        result.error = error;
+        return result;
+    }
+
+    protected filterRegexp(): RegExp {
+        return HappensDateField.happensRegexp;
+    }
+
+    protected fieldName(): string {
+        return 'happens';
+    }
+}

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -6,7 +6,10 @@ import { FilterOrErrorMessage } from './Filter';
 export class HappensDateField extends Field {
     private static readonly happensRegexp = /^happens (before|after|on)? ?(.*)/;
 
-    createFilterOrErrorMessage(line: string): { filter: any; error: any } {
+    public createFilterOrErrorMessage(line: string): {
+        filter: any;
+        error: any;
+    } {
         let filter;
         let error;
         const happensMatch = line.match(this.filterRegexp());

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -10,16 +10,15 @@ export class HappensDateField extends Field {
         filter: any;
         error: any;
     } {
-        let filter;
-        let error;
+        const result = new FilterOrErrorMessage();
         const happensMatch = line.match(this.filterRegexp());
         if (happensMatch !== null) {
             const filterDate = Query.parseDate(happensMatch[2]);
             if (!filterDate.isValid()) {
-                error = 'do not understand happens date';
+                result.error = 'do not understand happens date';
             } else {
                 if (happensMatch[1] === 'before') {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         return Array.of(
                             task.startDate,
                             task.scheduledDate,
@@ -27,7 +26,7 @@ export class HappensDateField extends Field {
                         ).some((date) => date && date.isBefore(filterDate));
                     };
                 } else if (happensMatch[1] === 'after') {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         return Array.of(
                             task.startDate,
                             task.scheduledDate,
@@ -35,7 +34,7 @@ export class HappensDateField extends Field {
                         ).some((date) => date && date.isAfter(filterDate));
                     };
                 } else {
-                    filter = (task: Task) => {
+                    result.filter = (task: Task) => {
                         return Array.of(
                             task.startDate,
                             task.scheduledDate,
@@ -45,11 +44,8 @@ export class HappensDateField extends Field {
                 }
             }
         } else {
-            error = 'do not understand query filter (happens date)';
+            result.error = 'do not understand query filter (happens date)';
         }
-        const result = new FilterOrErrorMessage();
-        result.filter = filter;
-        result.error = error;
         return result;
     }
 

--- a/src/Query/Filter/ScheduledDateField.ts
+++ b/src/Query/Filter/ScheduledDateField.ts
@@ -1,0 +1,18 @@
+import type { Moment } from 'moment';
+import type { Task } from '../../Task';
+import { DateField } from './DateField';
+
+export class ScheduledDateField extends DateField {
+    private static readonly scheduledRegexp =
+        /^scheduled (before|after|on)? ?(.*)/;
+
+    protected filterRegexp(): RegExp {
+        return ScheduledDateField.scheduledRegexp;
+    }
+    protected fieldName(): string {
+        return 'scheduled';
+    }
+    protected date(task: Task): Moment | null {
+        return task.scheduledDate;
+    }
+}

--- a/src/Query/Filter/ScheduledDateField.ts
+++ b/src/Query/Filter/ScheduledDateField.ts
@@ -2,6 +2,9 @@ import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { DateField } from './DateField';
 
+/**
+ * Support the 'scheduled' search instruction.
+ */
 export class ScheduledDateField extends DateField {
     private static readonly scheduledRegexp =
         /^scheduled (before|after|on)? ?(.*)/;

--- a/src/Query/Filter/ScheduledDateField.ts
+++ b/src/Query/Filter/ScheduledDateField.ts
@@ -15,4 +15,7 @@ export class ScheduledDateField extends DateField {
     protected date(task: Task): Moment | null {
         return task.scheduledDate;
     }
+    protected filterResultIfFieldMissing() {
+        return false;
+    }
 }

--- a/src/Query/Filter/StartDateField.ts
+++ b/src/Query/Filter/StartDateField.ts
@@ -2,6 +2,9 @@ import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { DateField } from './DateField';
 
+/**
+ * Support the 'starts' search instruction.
+ */
 export class StartDateField extends DateField {
     private static readonly startRegexp = /^starts (before|after|on)? ?(.*)/;
 

--- a/src/Query/Filter/StartDateField.ts
+++ b/src/Query/Filter/StartDateField.ts
@@ -1,0 +1,21 @@
+import type { Moment } from 'moment';
+import type { Task } from '../../Task';
+import { DateField } from './DateField';
+
+export class StartDateField extends DateField {
+    private static readonly startRegexp = /^starts (before|after|on)? ?(.*)/;
+
+    protected filterRegexp(): RegExp {
+        return StartDateField.startRegexp;
+    }
+    protected fieldName(): string {
+        return 'start';
+    }
+    protected date(task: Task): Moment | null {
+        return task.startDate;
+    }
+    protected filterResultIfFieldMissing() {
+        // reference: https://schemar.github.io/obsidian-tasks/queries/filters/#start-date
+        return true;
+    }
+}

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -537,7 +537,7 @@ describe('Query', () => {
         ];
 
         test.concurrent.each<[string, FilteringCase]>(TagFilteringCases)(
-            'should filter with done %s',
+            'should filter with scheduled %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {
                 shouldSupportFiltering(filters, allTaskLines, expectedResult);
             },

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -494,6 +494,31 @@ describe('Query', () => {
         });
     });
 
+    describe('filtering with "done"', () => {
+        const TagFilteringCases: Array<[string, FilteringCase]> = [
+            [
+                'done before',
+                {
+                    filters: ['done before 2022-12-23'],
+                    tasks: [
+                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
+                        '- [ ] I have no done date, so should fail',
+                    ],
+                    expectedResult: [
+                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
+                    ],
+                },
+            ],
+        ];
+
+        test.concurrent.each<[string, FilteringCase]>(TagFilteringCases)(
+            'should filter with done %s',
+            (_, { tasks: allTaskLines, filters, expectedResult }) => {
+                shouldSupportFiltering(filters, allTaskLines, expectedResult);
+            },
+        );
+    });
+
     describe('filtering with "happens"', () => {
         type HappensCase = {
             description: string;

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -519,6 +519,31 @@ describe('Query', () => {
         );
     });
 
+    describe('filtering with "scheduled"', () => {
+        const TagFilteringCases: Array<[string, FilteringCase]> = [
+            [
+                'scheduled after',
+                {
+                    filters: ['scheduled after 2022-12-23'],
+                    tasks: [
+                        '- [ ] I am scheduled after filter, and should pass ⏳ 2022-12-31',
+                        '- [ ] I have no scheduled date, so should fail',
+                    ],
+                    expectedResult: [
+                        '- [ ] I am scheduled after filter, and should pass ⏳ 2022-12-31',
+                    ],
+                },
+            ],
+        ];
+
+        test.concurrent.each<[string, FilteringCase]>(TagFilteringCases)(
+            'should filter with done %s',
+            (_, { tasks: allTaskLines, filters, expectedResult }) => {
+                shouldSupportFiltering(filters, allTaskLines, expectedResult);
+            },
+        );
+    });
+
     describe('filtering with "happens"', () => {
         type HappensCase = {
             description: string;

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -269,6 +269,19 @@ describe('Query', () => {
                     expectedResult: ['- [ ] task 2 ⏳ 2022-04-15'],
                 },
             ],
+            [
+                'by done date (before)',
+                {
+                    filters: ['done before 2022-12-23'],
+                    tasks: [
+                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
+                        '- [ ] I have no done date, so should fail',
+                    ],
+                    expectedResult: [
+                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
+                    ],
+                },
+            ],
         ])(
             'should support filtering %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {
@@ -492,56 +505,6 @@ describe('Query', () => {
             // Cleanup
             updateSettings(originalSettings);
         });
-    });
-
-    describe('filtering with "done"', () => {
-        const TagFilteringCases: Array<[string, FilteringCase]> = [
-            [
-                'done before',
-                {
-                    filters: ['done before 2022-12-23'],
-                    tasks: [
-                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
-                        '- [ ] I have no done date, so should fail',
-                    ],
-                    expectedResult: [
-                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
-                    ],
-                },
-            ],
-        ];
-
-        test.concurrent.each<[string, FilteringCase]>(TagFilteringCases)(
-            'should filter with done %s',
-            (_, { tasks: allTaskLines, filters, expectedResult }) => {
-                shouldSupportFiltering(filters, allTaskLines, expectedResult);
-            },
-        );
-    });
-
-    describe('filtering with "scheduled"', () => {
-        const TagFilteringCases: Array<[string, FilteringCase]> = [
-            [
-                'scheduled after',
-                {
-                    filters: ['scheduled after 2022-12-23'],
-                    tasks: [
-                        '- [ ] I am scheduled after filter, and should pass ⏳ 2022-12-31',
-                        '- [ ] I have no scheduled date, so should fail',
-                    ],
-                    expectedResult: [
-                        '- [ ] I am scheduled after filter, and should pass ⏳ 2022-12-31',
-                    ],
-                },
-            ],
-        ];
-
-        test.concurrent.each<[string, FilteringCase]>(TagFilteringCases)(
-            'should filter with scheduled %s',
-            (_, { tasks: allTaskLines, filters, expectedResult }) => {
-                shouldSupportFiltering(filters, allTaskLines, expectedResult);
-            },
-        );
     });
 
     describe('filtering with "happens"', () => {


### PR DESCRIPTION
(_Interesting that the PR template didn't appear for me_)

Hi @schemar @sytone,

I've mentioned recently that I could see ways to make simple changes to the `Query` code to greatly simplify the creation of filters and the maintenance of the `Query` class.

This PR started as an experiment to try this on one or two of the date filters, and it went well enough that I decided to pursue it and pull out the code for all the date filters (the ones with `before`, `after`, `on`).

## tl;dr

I'm moving code out of `Query` and into much smaller classes with single responsibilities, such as `DueDateField`. A ton of boiler plate code has disappeared as a result.

This is done for the date filters, and I will soon do it for the other filters.

`Query.test.ts` is still very big. I will soon divide up its tests to match the new classes.

Adding new types of filters will immediately become very obvious and very easy.

Enjoy!

## Classes added

- Add `DoneDateField`, `DueDateField`, `HappensDateField`, `ScheduledDateField` and `StartDateField`
- Add base classes of these: `DateField`, which inherits `Field`.
- These all have jsdoc comments explaining the naming, intention and possible future directions.
- See also `Filter.ts` for some supporting types.

## Tests

- So far, all this is covered by existing tests in `Query.test.js`

- Later I will likely create `DueDateField.test.ts` etc files for each of the new filters, and move most of the existing tests in `Query.test.ts` to the corresponding filter tests.

## Example code

For example, this is all the code that is needed to implement the `due before|after\on` instruction now:

```typescript
import type { Moment } from 'moment';
import type { Task } from '../../Task';
import { DateField } from './DateField';

/**
 * Support the 'due' search instruction.
 */
export class DueDateField extends DateField {
    private static readonly dueRegexp = /^due (before|after|on)? ?(.*)/;

    protected filterRegexp(): RegExp {
        return DueDateField.dueRegexp;
    }
    protected fieldName(): string {
        return 'due';
    }
    protected date(task: Task): Moment | null {
        return task.dueDate;
    }
    protected filterResultIfFieldMissing() {
        return false;
    }
}
```

Imagine if we added a `created before|after|on` instruction. How little code would be required to implement it, and therefore to test it.

## Query

`Query.ts` has shrunk from 653 lines to 511, and by the time I've done the same for the other filter instructions, it will be a lot smaller still.

Aside from imports, the total code for using these new classes is now this:

```typescript
                    case this.parseFilter(line, new HappensDateField()):
                        break;
                    case this.parseFilter(line, new StartDateField()):
                        break;
                    case this.parseFilter(line, new ScheduledDateField()):
                        break;
                    case this.parseFilter(line, new DueDateField()):
                        break;
                    case this.parseFilter(line, new DoneDateField()):
                        break;
```

Later on, the objects may well get added to a container of fields, and looped over, but for now the easiest way to slot them in to the existing code was via these function calls.

I think of this as all basically a rather simple implementation of the [Chain of Responsibility design pattern](https://refactoring.guru/design-patterns/chain-of-responsibility).

All the current repetitious parsing functions have been replaced by a single new `parseFilter()` function in `Query`:

```typescript
    private parseFilter(line: string, field: Field) {
        if (field.canCreateFilterForLine(line)) {
            const { filter, error } = field.createFilterOrErrorMessage(line);

            if (filter) {
                this._filters.push(filter);
            } else {
                this._error = error;
            }
            return true;
        } else {
            return false;
        }
    }

```

## Later stages

Depending on where the refactoring work takes me, these are the sorts of things I'm likely to do soon, to build on this work.

- Other filters: I really like how this turned out, so I plan to go ahead and port the remaining filters to this pattern.
- Re-implement the `happens` filter in terms of code extracted from `DateField`.
- Once I've done that, it will become very easy to implement new date-search features, as there will be a single location to update - perhaps searching by week number, or maybe date ranges, or dates of the week. Who knows? The world is our oyster!