### PR TITLE
Add TaskBuilder class for writing small tests

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -1,4 +1,3 @@
-import * as chrono from 'chrono-node';
 import { Group } from './Query/Group';
 import type { TaskGroups } from './Query/TaskGroups';
 
@@ -492,11 +491,6 @@ export class Query {
         } else {
             this._error = 'do not understand query grouping';
         }
-    }
-
-    public static parseDate(input: string): moment.Moment {
-        // Using start of day to correctly match on comparison with other dates (like equality).
-        return window.moment(chrono.parseDate(input)).startOf('day');
     }
 
     private static stringIncludesCaseInsensitive(

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -1,0 +1,8 @@
+import * as chrono from 'chrono-node';
+
+export class DateParser {
+    public static parseDate(input: string): moment.Moment {
+        // Using start of day to correctly match on comparison with other dates (like equality).
+        return window.moment(chrono.parseDate(input)).startOf('day');
+    }
+}

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -1,6 +1,6 @@
 import type { Moment } from 'moment';
-import { Query } from '../../Query';
 import type { Task } from '../../Task';
+import { DateParser } from '../DateParser';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
@@ -14,7 +14,7 @@ export abstract class DateField extends Field {
         const result = new FilterOrErrorMessage();
         const match = line.match(this.filterRegexp());
         if (match !== null) {
-            const filterDate = Query.parseDate(match[2]);
+            const filterDate = DateParser.parseDate(match[2]);
             if (!filterDate.isValid()) {
                 result.error =
                     'do not understand ' + this.fieldName() + ' date';

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -1,5 +1,5 @@
 import type { Task } from '../../Task';
-import { Query } from '../../Query';
+import { DateParser } from '../DateParser';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
@@ -14,7 +14,7 @@ export class HappensDateField extends Field {
         const result = new FilterOrErrorMessage();
         const happensMatch = line.match(this.filterRegexp());
         if (happensMatch !== null) {
-            const filterDate = Query.parseDate(happensMatch[2]);
+            const filterDate = DateParser.parseDate(happensMatch[2]);
             if (!filterDate.isValid()) {
                 result.error = 'do not understand happens date';
             } else {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -244,19 +244,6 @@ describe('Query', () => {
                 },
             ],
             [
-                'by due date (before)',
-                {
-                    filters: ['due before 2022-04-20'],
-                    tasks: [
-                        '- [ ] task 1',
-                        '- [ ] task 2 📅 2022-04-15',
-                        '- [ ] task 3 📅 2022-04-20',
-                        '- [ ] task 4 📅 2022-04-25',
-                    ],
-                    expectedResult: ['- [ ] task 2 📅 2022-04-15'],
-                },
-            ],
-            [
                 'by scheduled date (before)',
                 {
                     filters: ['scheduled before 2022-04-20'],

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -19,6 +19,15 @@ function testTaskFilter(
     expect(filter.filter!(task)).toEqual(expected);
 }
 
+function testTaskFilterForTaskWithDueDate(
+    filter: FilterOrErrorMessage,
+    builder: TaskBuilder,
+    dueDate: string | null,
+    expected: boolean,
+) {
+    testTaskFilter(filter, builder.dueDate(dueDate).build(), expected);
+}
+
 describe('due date', () => {
     it('by due date (before)', () => {
         // Arrange
@@ -28,9 +37,9 @@ describe('due date', () => {
         const builder = new TaskBuilder();
 
         // Act, Assert
-        testTaskFilter(filter, builder.dueDate(null).build(), false);
-        testTaskFilter(filter, builder.dueDate('2022-04-15').build(), true);
-        testTaskFilter(filter, builder.dueDate('2022-04-20').build(), false);
-        testTaskFilter(filter, builder.dueDate('2022-04-25').build(), false);
+        testTaskFilterForTaskWithDueDate(filter, builder, null, false);
+        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-15', true);
+        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-20', false);
+        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-25', false);
     });
 });

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -21,10 +21,10 @@ function testTaskFilter(
 
 function testTaskFilterForTaskWithDueDate(
     filter: FilterOrErrorMessage,
-    builder: TaskBuilder,
     dueDate: string | null,
     expected: boolean,
 ) {
+    const builder = new TaskBuilder();
     testTaskFilter(filter, builder.dueDate(dueDate).build(), expected);
 }
 
@@ -34,12 +34,11 @@ describe('due date', () => {
         const filter = new DueDateField().createFilterOrErrorMessage(
             'due before 2022-04-20',
         );
-        const builder = new TaskBuilder();
 
         // Act, Assert
-        testTaskFilterForTaskWithDueDate(filter, builder, null, false);
-        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-15', true);
-        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-20', false);
-        testTaskFilterForTaskWithDueDate(filter, builder, '2022-04-25', false);
+        testTaskFilterForTaskWithDueDate(filter, null, false);
+        testTaskFilterForTaskWithDueDate(filter, '2022-04-15', true);
+        testTaskFilterForTaskWithDueDate(filter, '2022-04-20', false);
+        testTaskFilterForTaskWithDueDate(filter, '2022-04-25', false);
     });
 });

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import type { Task } from '../../../src/Task';
-import { TaskBuilder } from './TaskBuilder';
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 
 window.moment = moment;
 

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -3,9 +3,21 @@
  */
 import moment from 'moment';
 import { DueDateField } from '../../../src/Query/Filter/DueDateField';
+import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+import type { Task } from '../../../src/Task';
 import { TaskBuilder } from './TaskBuilder';
 
 window.moment = moment;
+
+function testTaskFilter(
+    filter: FilterOrErrorMessage,
+    task: Task,
+    expected: boolean,
+) {
+    expect(filter.filter).toBeDefined();
+    expect(filter.error).toBeUndefined();
+    expect(filter.filter!(task)).toEqual(expected);
+}
 
 describe('due date', () => {
     it('by due date (before)', () => {
@@ -14,19 +26,11 @@ describe('due date', () => {
             'due before 2022-04-20',
         );
         const builder = new TaskBuilder();
-        // Assert
-        expect(filter.filter).toBeDefined();
-        expect(filter.error).toBeUndefined();
 
-        expect(filter.filter!(builder.dueDate(null).build())).toEqual(false);
-        expect(filter.filter!(builder.dueDate('2022-04-15').build())).toEqual(
-            true,
-        );
-        expect(filter.filter!(builder.dueDate('2022-04-20').build())).toEqual(
-            false,
-        );
-        expect(filter.filter!(builder.dueDate('2022-04-25').build())).toEqual(
-            false,
-        );
+        // Act, Assert
+        testTaskFilter(filter, builder.dueDate(null).build(), false);
+        testTaskFilter(filter, builder.dueDate('2022-04-15').build(), true);
+        testTaskFilter(filter, builder.dueDate('2022-04-20').build(), false);
+        testTaskFilter(filter, builder.dueDate('2022-04-25').build(), false);
     });
 });

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+import { DueDateField } from '../../../src/Query/Filter/DueDateField';
+import { TaskBuilder } from './TaskBuilder';
+
+window.moment = moment;
+
+describe('due date', () => {
+    it('parses a task from a line', () => {
+        // Arrange
+        // Arrange
+        const filterOrError = new DueDateField().createFilterOrErrorMessage(
+            'due on today',
+        );
+        const builder = new TaskBuilder();
+        const taskWithoutDueDate = builder.dueDate(null).build();
+
+        // Assert
+        expect(filterOrError.filter).toBeDefined();
+        expect(filterOrError.error).toBeUndefined();
+
+        expect(filterOrError.filter!(taskWithoutDueDate)).toEqual(false);
+    });
+});

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -9,6 +9,13 @@ import { TaskBuilder } from './TaskBuilder';
 
 window.moment = moment;
 
+/**
+ * Convenience function to test a Filter on a single Task
+ *
+ * @param filter - a FilterOrErrorMessage, which should have a valid Filter.
+ * @param task - the Task to filter.
+ * @param expected true if the task should match the filter, and false otherwise.
+ */
 function testTaskFilter(
     filter: FilterOrErrorMessage,
     task: Task,

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -8,19 +8,25 @@ import { TaskBuilder } from './TaskBuilder';
 window.moment = moment;
 
 describe('due date', () => {
-    it('parses a task from a line', () => {
+    it('by due date (before)', () => {
         // Arrange
-        // Arrange
-        const filterOrError = new DueDateField().createFilterOrErrorMessage(
-            'due on today',
+        const filter = new DueDateField().createFilterOrErrorMessage(
+            'due before 2022-04-20',
         );
         const builder = new TaskBuilder();
-        const taskWithoutDueDate = builder.dueDate(null).build();
-
         // Assert
-        expect(filterOrError.filter).toBeDefined();
-        expect(filterOrError.error).toBeUndefined();
+        expect(filter.filter).toBeDefined();
+        expect(filter.error).toBeUndefined();
 
-        expect(filterOrError.filter!(taskWithoutDueDate)).toEqual(false);
+        expect(filter.filter!(builder.dueDate(null).build())).toEqual(false);
+        expect(filter.filter!(builder.dueDate('2022-04-15').build())).toEqual(
+            true,
+        );
+        expect(filter.filter!(builder.dueDate('2022-04-20').build())).toEqual(
+            false,
+        );
+        expect(filter.filter!(builder.dueDate('2022-04-25').build())).toEqual(
+            false,
+        );
     });
 });

--- a/tests/Query/Filter/TaskBuilder.ts
+++ b/tests/Query/Filter/TaskBuilder.ts
@@ -153,7 +153,7 @@ export class TaskBuilder {
         return this;
     }
 
-    private static parseDate(date: string | null): moment.Moment | null {
+    private static parseDate(date: string | null): Moment | null {
         if (date) {
             return DateParser.parseDate(date);
         } else {

--- a/tests/Query/Filter/TaskBuilder.ts
+++ b/tests/Query/Filter/TaskBuilder.ts
@@ -134,11 +134,7 @@ export class TaskBuilder {
     }
 
     public dueDate(dueDate: string | null): TaskBuilder {
-        if (dueDate) {
-            this._dueDate = DateParser.parseDate(dueDate);
-        } else {
-            this._dueDate = null;
-        }
+        this._dueDate = TaskBuilder.parseDate(dueDate);
         return this;
     }
 
@@ -155,5 +151,13 @@ export class TaskBuilder {
     public blockLink(blockLink: string): TaskBuilder {
         this._blockLink = blockLink;
         return this;
+    }
+
+    private static parseDate(date: string | null): moment.Moment | null {
+        if (date) {
+            return DateParser.parseDate(date);
+        } else {
+            return null;
+        }
     }
 }

--- a/tests/Query/Filter/TaskBuilder.ts
+++ b/tests/Query/Filter/TaskBuilder.ts
@@ -123,13 +123,13 @@ export class TaskBuilder {
         return this;
     }
 
-    public startDate(startDate: Moment | null): TaskBuilder {
-        this._startDate = startDate;
+    public startDate(startDate: string | null): TaskBuilder {
+        this._startDate = TaskBuilder.parseDate(startDate);
         return this;
     }
 
-    public scheduledDate(scheduledDate: Moment | null): TaskBuilder {
-        this._scheduledDate = scheduledDate;
+    public scheduledDate(scheduledDate: string | null): TaskBuilder {
+        this._scheduledDate = TaskBuilder.parseDate(scheduledDate);
         return this;
     }
 
@@ -138,8 +138,8 @@ export class TaskBuilder {
         return this;
     }
 
-    public doneDate(doneDate: Moment | null): TaskBuilder {
-        this._doneDate = doneDate;
+    public doneDate(doneDate: string | null): TaskBuilder {
+        this._doneDate = TaskBuilder.parseDate(doneDate);
         return this;
     }
 

--- a/tests/Query/Filter/TaskBuilder.ts
+++ b/tests/Query/Filter/TaskBuilder.ts
@@ -1,0 +1,149 @@
+// Builder
+import type { Moment } from 'moment';
+import { Priority, Status, Task } from '../../../src/Task';
+import type { Recurrence } from '../../../src/Recurrence';
+
+/**
+ * A fluent class for creating tasks for tests.
+ *
+ * This uses the Builder Pattern.
+ *
+ * See TaskBuilder.build() for an example of use.
+ */
+export class TaskBuilder {
+    private _status: Status = Status.Todo;
+    private _description: string = 'my description';
+    private _path: string = '';
+    private _indentation: string = '';
+
+    private _sectionStart: number = 0;
+    private _sectionIndex: number = 0;
+
+    private _originalStatusCharacter: string = '';
+    private _precedingHeader: string | null = null;
+    private _tags: string[] = [];
+    private _priority: Priority = Priority.None;
+
+    private _startDate: Moment | null = null;
+    private _scheduledDate: Moment | null = null;
+    private _dueDate: Moment | null = null;
+    private _doneDate: Moment | null = null;
+
+    private _recurrence: Recurrence | null = null;
+    private _blockLink: string = '';
+
+    /**
+     * Build a Task
+     *
+     * Example of use:
+     *
+     *  const builder = new TaskBuilder();
+     *  const task = builder
+     *      .description('hello world')
+     *      .priority(Priority.High)
+     *      .path('root/dir 1/dir 2/file name')
+     *      .build();
+     */
+    public build(): Task {
+        return new Task({
+            status: this._status,
+            description: this._description,
+            path: this._path,
+            indentation: this._indentation,
+            sectionStart: this._sectionStart,
+            sectionIndex: this._sectionIndex,
+            originalStatusCharacter: this._originalStatusCharacter,
+            precedingHeader: this._precedingHeader,
+            priority: this._priority,
+            startDate: this._startDate,
+            scheduledDate: this._scheduledDate,
+            dueDate: this._dueDate,
+            doneDate: this._doneDate,
+            recurrence: this._recurrence,
+            blockLink: this._blockLink,
+            tags: this._tags,
+        });
+    }
+
+    public status(status: Status): TaskBuilder {
+        this._status = status;
+        return this;
+    }
+
+    public description(description: string): TaskBuilder {
+        this._description = description;
+        return this;
+    }
+
+    public path(path: string): TaskBuilder {
+        this._path = path;
+        return this;
+    }
+
+    public indentation(indentation: string): TaskBuilder {
+        this._indentation = indentation;
+        return this;
+    }
+
+    public sectionStart(sectionStart: number): TaskBuilder {
+        this._sectionStart = sectionStart;
+        return this;
+    }
+
+    public sectionIndex(sectionIndex: number): TaskBuilder {
+        this._sectionIndex = sectionIndex;
+        return this;
+    }
+
+    public originalStatusCharacter(
+        originalStatusCharacter: string,
+    ): TaskBuilder {
+        this._originalStatusCharacter = originalStatusCharacter;
+        return this;
+    }
+
+    public precedingHeader(precedingHeader: string | null): TaskBuilder {
+        this._precedingHeader = precedingHeader;
+        return this;
+    }
+
+    public tags(tags: string[]): TaskBuilder {
+        this._tags = tags;
+        return this;
+    }
+
+    public priority(priority: Priority): TaskBuilder {
+        this._priority = priority;
+        return this;
+    }
+
+    public startDate(startDate: Moment | null): TaskBuilder {
+        this._startDate = startDate;
+        return this;
+    }
+
+    public scheduledDate(scheduledDate: Moment | null): TaskBuilder {
+        this._scheduledDate = scheduledDate;
+        return this;
+    }
+
+    public dueDate(dueDate: Moment | null): TaskBuilder {
+        this._dueDate = dueDate;
+        return this;
+    }
+
+    public doneDate(doneDate: Moment | null): TaskBuilder {
+        this._doneDate = doneDate;
+        return this;
+    }
+
+    public recurrence(recurrence: Recurrence | null): TaskBuilder {
+        this._recurrence = recurrence;
+        return this;
+    }
+
+    public blockLink(blockLink: string): TaskBuilder {
+        this._blockLink = blockLink;
+        return this;
+    }
+}

--- a/tests/Query/Filter/TaskBuilder.ts
+++ b/tests/Query/Filter/TaskBuilder.ts
@@ -2,6 +2,7 @@
 import type { Moment } from 'moment';
 import { Priority, Status, Task } from '../../../src/Task';
 import type { Recurrence } from '../../../src/Recurrence';
+import { DateParser } from '../../../src/Query/DateParser';
 
 /**
  * A fluent class for creating tasks for tests.
@@ -9,6 +10,11 @@ import type { Recurrence } from '../../../src/Recurrence';
  * This uses the Builder Pattern.
  *
  * See TaskBuilder.build() for an example of use.
+ *
+ * IMPORTANT: Changed values are retained after calls to .build()
+ *            There is no way to reset a TaskBuilder to its default
+ *            start currently.
+ *            Create a new TaskBuilder object to start from a clean state,
  */
 export class TaskBuilder {
     private _status: Status = Status.Todo;
@@ -127,8 +133,12 @@ export class TaskBuilder {
         return this;
     }
 
-    public dueDate(dueDate: Moment | null): TaskBuilder {
-        this._dueDate = dueDate;
+    public dueDate(dueDate: string | null): TaskBuilder {
+        if (dueDate) {
+            this._dueDate = DateParser.parseDate(dueDate);
+        } else {
+            this._dueDate = null;
+        }
         return this;
     }
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -1,8 +1,8 @@
 // Builder
 import type { Moment } from 'moment';
-import { Priority, Status, Task } from '../../../src/Task';
-import type { Recurrence } from '../../../src/Recurrence';
-import { DateParser } from '../../../src/Query/DateParser';
+import { Priority, Status, Task } from '../../src/Task';
+import type { Recurrence } from '../../src/Recurrence';
+import { DateParser } from '../../src/Query/DateParser';
 
 /**
  * A fluent class for creating tasks for tests.


### PR DESCRIPTION
## Problem

Creating tests that use due date, start date etc involves a lot of emojis, and setting of data that doesn't matter, like task descriptions.

Also, the tests that take a list of task strings, and then return only the tasks that match a filter, have turned out to contain duplicated text (for tasks that match the filter) and require some careful examination to establish which tasks missed the filter, and why.

I wanted to:

1. see if the Builder Pattern would be helpful for writing tests of particular task properties.
2. see if I can make it more explicit which tasks matched a filter and which not in small tests.

## TaskBuilder class

Some example code using `TaskBuilder`:

```typescript
const builder = new TaskBuilder();
const task = builder
    .description('hello world')
    .priority(Priority.High)
    .path('root/dir 1/dir 2/file name')
    .build();
```

All method calls are optional except the final `.build()`

## Changes made

- Add `tests/TestingTools/TaskBuilder.ts`. See docs there for more info.
- Create `src/Query/DateParser.ts` to break cyclic dependency between `Query` and `DateField`
- Move a `due before` test from `tests/Query.test.ts` to new file `tests/Query/Filter/DueDateField.test.ts`
- `tests/Query/Filter/DueDateField.test.ts` contains some experimental helper functions for testing the filters implemented in the `Field` classes.
    - Some of these helpers may move to other files later on.
