### PR TITLE
refactor: Create text filter classes

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -9,6 +9,7 @@ import { Priority, Status, Task } from './Task';
 import type { Field } from './Query/Filter/Field';
 import { DoneDateField } from './Query/Filter/DoneDateField';
 import { DueDateField } from './Query/Filter/DueDateField';
+import { HeadingField } from './Query/Filter/HeadingField';
 import { PathField } from './Query/Filter/PathField';
 import { ScheduledDateField } from './Query/Filter/ScheduledDateField';
 import { StartDateField } from './Query/Filter/StartDateField';
@@ -78,9 +79,6 @@ export class Query {
 
     private readonly groupByRegexp =
         /^group by (backlink|filename|folder|heading|path|status)/;
-
-    private readonly headingRegexp =
-        /^heading (includes|does not include) (.*)/;
 
     private readonly hideOptionsRegexp =
         /^hide (task count|backlink|priority|start date|scheduled date|done date|due date|recurrence rule|edit button)/;
@@ -167,8 +165,7 @@ export class Query {
                     case this.tagRegexp.test(line):
                         this.parseTagFilter({ line });
                         break;
-                    case this.headingRegexp.test(line):
-                        this.parseHeadingFilter({ line });
+                    case this.parseFilter(line, new HeadingField()):
                         break;
                     case this.limitRegexp.test(line):
                         this.parseLimit({ line });
@@ -399,36 +396,6 @@ export class Query {
             }
         } else {
             this._error = 'do not understand query filter (description)';
-        }
-    }
-
-    private parseHeadingFilter({ line }: { line: string }): void {
-        const headingMatch = line.match(this.headingRegexp);
-        if (headingMatch !== null) {
-            const filterMethod = headingMatch[1].toLowerCase();
-            if (filterMethod === 'includes') {
-                this._filters.push(
-                    (task: Task) =>
-                        task.precedingHeader !== null &&
-                        TextField.stringIncludesCaseInsensitive(
-                            task.precedingHeader,
-                            headingMatch[2],
-                        ),
-                );
-            } else if (headingMatch[1] === 'does not include') {
-                this._filters.push(
-                    (task: Task) =>
-                        task.precedingHeader === null ||
-                        !TextField.stringIncludesCaseInsensitive(
-                            task.precedingHeader,
-                            headingMatch[2],
-                        ),
-                );
-            } else {
-                this._error = 'do not understand query filter (heading)';
-            }
-        } else {
-            this._error = 'do not understand query filter (heading)';
         }
     }
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -13,6 +13,7 @@ import { PathField } from './Query/Filter/PathField';
 import { ScheduledDateField } from './Query/Filter/ScheduledDateField';
 import { StartDateField } from './Query/Filter/StartDateField';
 import { HappensDateField } from './Query/Filter/HappensDateField';
+import { TextField } from './Query/Filter/TextField';
 
 export type SortingProperty =
     | 'urgency'
@@ -374,7 +375,7 @@ export class Query {
 
             if (filterMethod === 'includes') {
                 this._filters.push((task: Task) =>
-                    Query.stringIncludesCaseInsensitive(
+                    TextField.stringIncludesCaseInsensitive(
                         // Remove global filter from description match if present.
                         // This is necessary to match only on the content of the task, not
                         // the global filter.
@@ -385,7 +386,7 @@ export class Query {
             } else if (descriptionMatch[1] === 'does not include') {
                 this._filters.push(
                     (task: Task) =>
-                        !Query.stringIncludesCaseInsensitive(
+                        !TextField.stringIncludesCaseInsensitive(
                             // Remove global filter from description match if present.
                             // This is necessary to match only on the content of the task, not
                             // the global filter.
@@ -409,7 +410,7 @@ export class Query {
                 this._filters.push(
                     (task: Task) =>
                         task.precedingHeader !== null &&
-                        Query.stringIncludesCaseInsensitive(
+                        TextField.stringIncludesCaseInsensitive(
                             task.precedingHeader,
                             headingMatch[2],
                         ),
@@ -418,7 +419,7 @@ export class Query {
                 this._filters.push(
                     (task: Task) =>
                         task.precedingHeader === null ||
-                        !Query.stringIncludesCaseInsensitive(
+                        !TextField.stringIncludesCaseInsensitive(
                             task.precedingHeader,
                             headingMatch[2],
                         ),
@@ -463,14 +464,5 @@ export class Query {
         } else {
             this._error = 'do not understand query grouping';
         }
-    }
-
-    public static stringIncludesCaseInsensitive(
-        haystack: string,
-        needle: string,
-    ): boolean {
-        return haystack
-            .toLocaleLowerCase()
-            .includes(needle.toLocaleLowerCase());
     }
 }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -371,26 +371,25 @@ export class Query {
             const globalFilter = getSettings().globalFilter;
 
             if (filterMethod === 'includes') {
-                this._filters.push((task: Task) =>
+                const filter = (task: Task) =>
                     TextField.stringIncludesCaseInsensitive(
                         // Remove global filter from description match if present.
                         // This is necessary to match only on the content of the task, not
                         // the global filter.
                         task.description.replace(globalFilter, '').trim(),
                         descriptionMatch[2],
-                    ),
-                );
+                    );
+                this._filters.push(filter);
             } else if (descriptionMatch[1] === 'does not include') {
-                this._filters.push(
-                    (task: Task) =>
-                        !TextField.stringIncludesCaseInsensitive(
-                            // Remove global filter from description match if present.
-                            // This is necessary to match only on the content of the task, not
-                            // the global filter.
-                            task.description.replace(globalFilter, '').trim(),
-                            descriptionMatch[2],
-                        ),
-                );
+                const filter = (task: Task) =>
+                    !TextField.stringIncludesCaseInsensitive(
+                        // Remove global filter from description match if present.
+                        // This is necessary to match only on the content of the task, not
+                        // the global filter.
+                        task.description.replace(globalFilter, '').trim(),
+                        descriptionMatch[2],
+                    );
+                this._filters.push(filter);
             } else {
                 this._error = 'do not understand query filter (description)';
             }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -20,6 +20,11 @@ export class DescriptionField extends TextField {
         return DescriptionField.descriptionRegexp;
     }
 
+    /**
+     * Return the task's description, with any global tag removed
+     * @param task
+     * @protected
+     */
     protected value(task: Task): string {
         // Remove global filter from description match if present.
         // This is necessary to match only on the content of the task, not

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -1,46 +1,16 @@
 import { getSettings } from '../../Settings';
 import type { Task } from '../../Task';
-import { Field } from './Field';
-import { FilterOrErrorMessage } from './Filter';
 import { TextField } from './TextField';
 
-export class DescriptionField extends Field {
+/**
+ * Support the 'description' search instruction.
+ *
+ * Note that DescriptionField.value() returns the description
+ * with the global filter (if any) removed.
+ */
+export class DescriptionField extends TextField {
     private static readonly descriptionRegexp =
         /^description (includes|does not include) (.*)/;
-
-    createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage();
-        const descriptionMatch = line.match(DescriptionField.descriptionRegexp);
-        if (descriptionMatch !== null) {
-            const filterMethod = descriptionMatch[1];
-            const globalFilter = getSettings().globalFilter;
-
-            if (filterMethod === 'includes') {
-                result.filter = (task: Task) =>
-                    TextField.stringIncludesCaseInsensitive(
-                        // Remove global filter from description match if present.
-                        // This is necessary to match only on the content of the task, not
-                        // the global filter.
-                        task.description.replace(globalFilter, '').trim(),
-                        descriptionMatch[2],
-                    );
-            } else if (descriptionMatch[1] === 'does not include') {
-                result.filter = (task: Task) =>
-                    !TextField.stringIncludesCaseInsensitive(
-                        // Remove global filter from description match if present.
-                        // This is necessary to match only on the content of the task, not
-                        // the global filter.
-                        task.description.replace(globalFilter, '').trim(),
-                        descriptionMatch[2],
-                    );
-            } else {
-                result.error = 'do not understand query filter (description)';
-            }
-        } else {
-            result.error = 'do not understand query filter (description)';
-        }
-        return result;
-    }
 
     protected fieldName(): string {
         return 'description';
@@ -48,5 +18,13 @@ export class DescriptionField extends Field {
 
     protected filterRegexp(): RegExp {
         return DescriptionField.descriptionRegexp;
+    }
+
+    protected value(task: Task): string {
+        // Remove global filter from description match if present.
+        // This is necessary to match only on the content of the task, not
+        // the global filter.
+        const globalFilter = getSettings().globalFilter;
+        return task.description.replace(globalFilter, '').trim();
     }
 }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -1,0 +1,52 @@
+import { getSettings } from '../../Settings';
+import type { Task } from '../../Task';
+import { Field } from './Field';
+import { FilterOrErrorMessage } from './Filter';
+import { TextField } from './TextField';
+
+export class DescriptionField extends Field {
+    private static readonly descriptionRegexp =
+        /^description (includes|does not include) (.*)/;
+
+    createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage();
+        const descriptionMatch = line.match(DescriptionField.descriptionRegexp);
+        if (descriptionMatch !== null) {
+            const filterMethod = descriptionMatch[1];
+            const globalFilter = getSettings().globalFilter;
+
+            if (filterMethod === 'includes') {
+                result.filter = (task: Task) =>
+                    TextField.stringIncludesCaseInsensitive(
+                        // Remove global filter from description match if present.
+                        // This is necessary to match only on the content of the task, not
+                        // the global filter.
+                        task.description.replace(globalFilter, '').trim(),
+                        descriptionMatch[2],
+                    );
+            } else if (descriptionMatch[1] === 'does not include') {
+                result.filter = (task: Task) =>
+                    !TextField.stringIncludesCaseInsensitive(
+                        // Remove global filter from description match if present.
+                        // This is necessary to match only on the content of the task, not
+                        // the global filter.
+                        task.description.replace(globalFilter, '').trim(),
+                        descriptionMatch[2],
+                    );
+            } else {
+                result.error = 'do not understand query filter (description)';
+            }
+        } else {
+            result.error = 'do not understand query filter (description)';
+        }
+        return result;
+    }
+
+    protected fieldName(): string {
+        return 'description';
+    }
+
+    protected filterRegexp(): RegExp {
+        return DescriptionField.descriptionRegexp;
+    }
+}

--- a/src/Query/Filter/HeadingField.ts
+++ b/src/Query/Filter/HeadingField.ts
@@ -1,6 +1,9 @@
 import type { Task } from '../../Task';
 import { TextField } from './TextField';
 
+/** Support the 'heading' search instruction.
+ *
+ */
 export class HeadingField extends TextField {
     private static readonly headingRegexp =
         /^heading (includes|does not include) (.*)/;

--- a/src/Query/Filter/HeadingField.ts
+++ b/src/Query/Filter/HeadingField.ts
@@ -1,0 +1,28 @@
+import type { Task } from '../../Task';
+import { TextField } from './TextField';
+
+export class HeadingField extends TextField {
+    private static readonly headingRegexp =
+        /^heading (includes|does not include) (.*)/;
+
+    protected filterRegexp(): RegExp {
+        return HeadingField.headingRegexp;
+    }
+
+    protected fieldName(): string {
+        return 'heading';
+    }
+
+    /**
+     * Returns the preceding heading, or an empty string if the heading is null
+     * @param task
+     * @protected
+     */
+    protected value(task: Task): string {
+        if (task.precedingHeader) {
+            return task.precedingHeader;
+        } else {
+            return '';
+        }
+    }
+}

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -9,26 +9,26 @@ export class PathField extends Field {
 
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
-        const pathMatch = line.match(PathField.pathRegexp);
-        if (pathMatch !== null) {
-            const filterMethod = pathMatch[1];
+        const match = line.match(this.filterRegexp());
+        if (match !== null) {
+            const filterMethod = match[1];
             if (filterMethod === 'includes') {
                 result.filter = (task: Task) =>
                     Query.stringIncludesCaseInsensitive(
-                        task.path,
-                        pathMatch[2],
+                        this.value(task),
+                        match[2],
                     );
-            } else if (pathMatch[1] === 'does not include') {
+            } else if (match[1] === 'does not include') {
                 result.filter = (task: Task) =>
                     !Query.stringIncludesCaseInsensitive(
-                        task.path,
-                        pathMatch[2],
+                        this.value(task),
+                        match[2],
                     );
             } else {
-                result.error = 'do not understand query filter (path)';
+                result.error = `do not understand query filter (${this.fieldName()})`;
             }
         } else {
-            result.error = 'do not understand query filter (path)';
+            result.error = `do not understand query filter (${this.fieldName()})`;
         }
         return result;
     }
@@ -39,5 +39,9 @@ export class PathField extends Field {
 
     protected fieldName(): string {
         return 'path';
+    }
+
+    protected value(task: Task): string {
+        return task.path;
     }
 }

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -19,6 +19,11 @@ export class PathField extends TextField {
         return 'path';
     }
 
+    /**
+     * Returns the file path including file extension, or an empty string if the path is null
+     * @param task
+     * @protected
+     */
     protected value(task: Task): string {
         return task.path;
     }

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -1,6 +1,9 @@
 import type { Task } from '../../Task';
 import { TextField } from './TextField';
 
+/** Support the 'path' search instruction.
+ *
+ */
 export class PathField extends TextField {
     private static readonly pathRegexp =
         /^path (includes|does not include) (.*)/;

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -1,37 +1,9 @@
-import { Query } from '../../Query';
 import type { Task } from '../../Task';
-import { Field } from './Field';
-import { FilterOrErrorMessage } from './Filter';
+import { TextField } from './TextField';
 
-export class PathField extends Field {
+export class PathField extends TextField {
     private static readonly pathRegexp =
         /^path (includes|does not include) (.*)/;
-
-    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage();
-        const match = line.match(this.filterRegexp());
-        if (match !== null) {
-            const filterMethod = match[1];
-            if (filterMethod === 'includes') {
-                result.filter = (task: Task) =>
-                    Query.stringIncludesCaseInsensitive(
-                        this.value(task),
-                        match[2],
-                    );
-            } else if (match[1] === 'does not include') {
-                result.filter = (task: Task) =>
-                    !Query.stringIncludesCaseInsensitive(
-                        this.value(task),
-                        match[2],
-                    );
-            } else {
-                result.error = `do not understand query filter (${this.fieldName()})`;
-            }
-        } else {
-            result.error = `do not understand query filter (${this.fieldName()})`;
-        }
-        return result;
-    }
 
     protected filterRegexp(): RegExp {
         return PathField.pathRegexp;

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -3,6 +3,9 @@ import { TextField } from './TextField';
 
 /** Support the 'path' search instruction.
  *
+ * Note that the current implementation also searches the file extension,
+ * so 'path includes .md' will typically match all tasks.
+ *
  */
 export class PathField extends TextField {
     private static readonly pathRegexp =

--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -1,0 +1,43 @@
+import { Query } from '../../Query';
+import type { Task } from '../../Task';
+import { Field } from './Field';
+import { FilterOrErrorMessage } from './Filter';
+
+export class PathField extends Field {
+    private static readonly pathRegexp =
+        /^path (includes|does not include) (.*)/;
+
+    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage();
+        const pathMatch = line.match(PathField.pathRegexp);
+        if (pathMatch !== null) {
+            const filterMethod = pathMatch[1];
+            if (filterMethod === 'includes') {
+                result.filter = (task: Task) =>
+                    Query.stringIncludesCaseInsensitive(
+                        task.path,
+                        pathMatch[2],
+                    );
+            } else if (pathMatch[1] === 'does not include') {
+                result.filter = (task: Task) =>
+                    !Query.stringIncludesCaseInsensitive(
+                        task.path,
+                        pathMatch[2],
+                    );
+            } else {
+                result.error = 'do not understand query filter (path)';
+            }
+        } else {
+            result.error = 'do not understand query filter (path)';
+        }
+        return result;
+    }
+
+    protected filterRegexp(): RegExp {
+        return PathField.pathRegexp;
+    }
+
+    protected fieldName(): string {
+        return 'path';
+    }
+}

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -2,6 +2,11 @@ import type { Task } from '../../Task';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
+/**
+ * TextField is an abstract base class to help implement
+ * all the filter instructions that act on a single type of string
+ * value, such as the description or file path.
+ */
 export abstract class TextField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -47,5 +47,10 @@ export abstract class TextField extends Field {
 
     protected abstract fieldName(): string;
 
+    /**
+     * Returns the field's value, or an empty string if the value is null
+     * @param task
+     * @protected
+     */
     protected abstract value(task: Task): string;
 }

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -1,0 +1,38 @@
+import type { Task } from '../../Task';
+import { Query } from '../../Query';
+import { Field } from './Field';
+import { FilterOrErrorMessage } from './Filter';
+
+export abstract class TextField extends Field {
+    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage();
+        const match = line.match(this.filterRegexp());
+        if (match !== null) {
+            const filterMethod = match[1];
+            if (filterMethod === 'includes') {
+                result.filter = (task: Task) =>
+                    Query.stringIncludesCaseInsensitive(
+                        this.value(task),
+                        match[2],
+                    );
+            } else if (match[1] === 'does not include') {
+                result.filter = (task: Task) =>
+                    !Query.stringIncludesCaseInsensitive(
+                        this.value(task),
+                        match[2],
+                    );
+            } else {
+                result.error = `do not understand query filter (${this.fieldName()})`;
+            }
+        } else {
+            result.error = `do not understand query filter (${this.fieldName()})`;
+        }
+        return result;
+    }
+
+    protected abstract filterRegexp(): RegExp;
+
+    protected abstract fieldName(): string;
+
+    protected abstract value(task: Task): string;
+}

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -1,5 +1,4 @@
 import type { Task } from '../../Task';
-import { Query } from '../../Query';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
@@ -11,13 +10,13 @@ export abstract class TextField extends Field {
             const filterMethod = match[1];
             if (filterMethod === 'includes') {
                 result.filter = (task: Task) =>
-                    Query.stringIncludesCaseInsensitive(
+                    TextField.stringIncludesCaseInsensitive(
                         this.value(task),
                         match[2],
                     );
             } else if (match[1] === 'does not include') {
                 result.filter = (task: Task) =>
-                    !Query.stringIncludesCaseInsensitive(
+                    !TextField.stringIncludesCaseInsensitive(
                         this.value(task),
                         match[2],
                     );
@@ -28,6 +27,15 @@ export abstract class TextField extends Field {
             result.error = `do not understand query filter (${this.fieldName()})`;
         }
         return result;
+    }
+
+    public static stringIncludesCaseInsensitive(
+        haystack: string,
+        needle: string,
+    ): boolean {
+        return haystack
+            .toLocaleLowerCase()
+            .includes(needle.toLocaleLowerCase());
     }
 
     protected abstract filterRegexp(): RegExp;

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -103,48 +103,6 @@ describe('Query', () => {
             expect(filteredTasks[0]).toEqual(tasks[0]);
         });
 
-        it('ignores the global filter when filtering', () => {
-            // Arrange
-            const originalSettings = getSettings();
-            updateSettings({ globalFilter: '#task' });
-            const filters: Array<string> = ['description includes task'];
-            const tasks: Array<string> = [
-                '- [ ] #task this does not include the word; only in the global filter',
-                '- [ ] #task this does: task',
-            ];
-            const expectedResult: Array<string> = [
-                '- [ ] #task this does: task',
-            ];
-
-            // Act, Assert
-            shouldSupportFiltering(filters, tasks, expectedResult);
-
-            // Cleanup
-            updateSettings(originalSettings);
-        });
-
-        it('works without a global filter', () => {
-            // Arrange
-            const originalSettings = getSettings();
-            updateSettings({ globalFilter: '' });
-            const filters: Array<string> = ['description includes task'];
-            const tasks: Array<string> = [
-                '- [ ] this does not include the word at all',
-                '- [ ] #task this includes the word as a tag',
-                '- [ ] #task this does: task',
-            ];
-            const expectedResult: Array<string> = [
-                '- [ ] #task this includes the word as a tag',
-                '- [ ] #task this does: task',
-            ];
-
-            // Act, Assert
-            shouldSupportFiltering(filters, tasks, expectedResult);
-
-            // Cleanup
-            updateSettings(originalSettings);
-        });
-
         test.concurrent.each<[string, FilteringCase]>([
             [
                 'by due date presence',

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -1,0 +1,11 @@
+import { DescriptionField } from '../../../src/Query/Filter/DescriptionField';
+
+describe('description', () => {
+    it('can instantiate', () => {
+        const filter = new DescriptionField().createFilterOrErrorMessage(
+            'description includes wibble',
+        );
+        expect(filter.filter).toBeDefined();
+        expect(filter.error).toBeUndefined();
+    });
+});

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -2,6 +2,18 @@ import { DescriptionField } from '../../../src/Query/Filter/DescriptionField';
 import { getSettings, updateSettings } from '../../../src/Settings';
 import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 import { fromLine } from '../../TestHelpers';
+import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+
+function testDescriptionFilter(
+    filter: FilterOrErrorMessage,
+    line: string,
+    expected: boolean,
+) {
+    const task = fromLine({
+        line,
+    });
+    testTaskFilter(filter, task, expected);
+}
 
 describe('description', () => {
     it('can instantiate', () => {
@@ -21,18 +33,13 @@ describe('description', () => {
         );
 
         // Act, Assert
-        testTaskFilter(
+        testDescriptionFilter(
             filter,
-            fromLine({
-                line: '- [ ] #task this does not include the word; only in the global filter',
-            })!,
+            '- [ ] #task this does not include the word; only in the global filter',
+
             false,
         );
-        testTaskFilter(
-            filter,
-            fromLine({ line: '- [ ] #task this does: task' })!,
-            true,
-        );
+        testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
         updateSettings(originalSettings);
@@ -47,29 +54,19 @@ describe('description', () => {
         );
 
         // Act, Assert
-        testTaskFilter(
+        testDescriptionFilter(
             filter,
-            fromLine({
-                line: '- [ ] this does not include the word at all',
-            })!,
+            '- [ ] this does not include the word at all',
             false,
         );
 
-        testTaskFilter(
+        testDescriptionFilter(
             filter,
-            fromLine({
-                line: '- [ ] #task this includes the word as a tag',
-            })!,
+            '- [ ] #task this includes the word as a tag',
             true,
         );
 
-        testTaskFilter(
-            filter,
-            fromLine({
-                line: '- [ ] #task this does: task',
-            })!,
-            true,
-        );
+        testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
         updateSettings(originalSettings);

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -16,14 +16,6 @@ function testDescriptionFilter(
 }
 
 describe('description', () => {
-    it('can instantiate', () => {
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description includes wibble',
-        );
-        expect(filter.filter).toBeDefined();
-        expect(filter.error).toBeUndefined();
-    });
-
     it('ignores the global filter when filtering', () => {
         // Arrange
         const originalSettings = getSettings();

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -1,4 +1,7 @@
 import { DescriptionField } from '../../../src/Query/Filter/DescriptionField';
+import { getSettings, updateSettings } from '../../../src/Settings';
+import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
+import { fromLine } from '../../TestHelpers';
 
 describe('description', () => {
     it('can instantiate', () => {
@@ -7,5 +10,68 @@ describe('description', () => {
         );
         expect(filter.filter).toBeDefined();
         expect(filter.error).toBeUndefined();
+    });
+
+    it('ignores the global filter when filtering', () => {
+        // Arrange
+        const originalSettings = getSettings();
+        updateSettings({ globalFilter: '#task' });
+        const filter = new DescriptionField().createFilterOrErrorMessage(
+            'description includes task',
+        );
+
+        // Act, Assert
+        testTaskFilter(
+            filter,
+            fromLine({
+                line: '- [ ] #task this does not include the word; only in the global filter',
+            })!,
+            false,
+        );
+        testTaskFilter(
+            filter,
+            fromLine({ line: '- [ ] #task this does: task' })!,
+            true,
+        );
+
+        // Cleanup
+        updateSettings(originalSettings);
+    });
+
+    it('works without a global filter', () => {
+        // Arrange
+        const originalSettings = getSettings();
+        updateSettings({ globalFilter: '' });
+        const filter = new DescriptionField().createFilterOrErrorMessage(
+            'description includes task',
+        );
+
+        // Act, Assert
+        testTaskFilter(
+            filter,
+            fromLine({
+                line: '- [ ] this does not include the word at all',
+            })!,
+            false,
+        );
+
+        testTaskFilter(
+            filter,
+            fromLine({
+                line: '- [ ] #task this includes the word as a tag',
+            })!,
+            true,
+        );
+
+        testTaskFilter(
+            filter,
+            fromLine({
+                line: '- [ ] #task this does: task',
+            })!,
+            true,
+        );
+
+        // Cleanup
+        updateSettings(originalSettings);
     });
 });

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -4,27 +4,10 @@
 import moment from 'moment';
 import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
-import type { Task } from '../../../src/Task';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 
 window.moment = moment;
-
-/**
- * Convenience function to test a Filter on a single Task
- *
- * @param filter - a FilterOrErrorMessage, which should have a valid Filter.
- * @param task - the Task to filter.
- * @param expected true if the task should match the filter, and false otherwise.
- */
-function testTaskFilter(
-    filter: FilterOrErrorMessage,
-    task: Task,
-    expected: boolean,
-) {
-    expect(filter.filter).toBeDefined();
-    expect(filter.error).toBeUndefined();
-    expect(filter.filter!(task)).toEqual(expected);
-}
 
 function testTaskFilterForTaskWithDueDate(
     filter: FilterOrErrorMessage,

--- a/tests/Query/Filter/HeadingField.test.ts
+++ b/tests/Query/Filter/HeadingField.test.ts
@@ -1,0 +1,43 @@
+import { HeadingField } from '../../../src/Query/Filter/HeadingField';
+import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
+
+function testTaskFilterForHeading(
+    filter: FilterOrErrorMessage,
+    precedingHeader: string | null,
+    expected: boolean,
+) {
+    const builder = new TaskBuilder();
+    testTaskFilter(
+        filter,
+        builder.precedingHeader(precedingHeader).build(),
+        expected,
+    );
+}
+
+describe('heading', () => {
+    it('by heading (includes)', () => {
+        // Arrange
+        const filter = new HeadingField().createFilterOrErrorMessage(
+            'heading includes Interesting Heading',
+        );
+
+        // Act, Assert
+        testTaskFilterForHeading(filter, null, false);
+        testTaskFilterForHeading(filter, 'An InteResting HeaDing', true);
+        testTaskFilterForHeading(filter, 'Other Heading', false);
+    });
+
+    it('by heading (does not include)', () => {
+        // Arrange
+        const filter = new HeadingField().createFilterOrErrorMessage(
+            'heading does not include Interesting Heading',
+        );
+
+        // Act, Assert
+        testTaskFilterForHeading(filter, null, true);
+        testTaskFilterForHeading(filter, 'SoMe InteResting HeaDing', false);
+        testTaskFilterForHeading(filter, 'Other Heading', true);
+    });
+});

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -1,0 +1,38 @@
+import { PathField } from '../../../src/Query/Filter/PathField';
+import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
+
+function testTaskFilterForTaskWithPath(
+    filter: FilterOrErrorMessage,
+    path: string,
+    expected: boolean,
+) {
+    const builder = new TaskBuilder();
+    testTaskFilter(filter, builder.path(path).build(), expected);
+}
+
+describe('path', () => {
+    it('by path (includes)', () => {
+        // Arrange
+        const filter = new PathField().createFilterOrErrorMessage(
+            'path includes some/path',
+        );
+
+        // Assert
+        testTaskFilterForTaskWithPath(filter, '/some/path/file.md', true);
+        testTaskFilterForTaskWithPath(filter, '/SoMe/PaTh/file.md', true);
+        testTaskFilterForTaskWithPath(filter, '/other/path/file.md', false);
+    });
+
+    it('by path (does not include)', () => {
+        // Arrange
+        const filter = new PathField().createFilterOrErrorMessage(
+            'path does not include some/path',
+        );
+
+        // Assert
+        testTaskFilterForTaskWithPath(filter, '/some/path/file.md', false);
+        testTaskFilterForTaskWithPath(filter, '/other/path/file.md', true);
+    });
+});

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -20,6 +20,7 @@ describe('path', () => {
         );
 
         // Assert
+        testTaskFilterForTaskWithPath(filter, '', false);
         testTaskFilterForTaskWithPath(filter, '/some/path/file.md', true);
         testTaskFilterForTaskWithPath(filter, '/SoMe/PaTh/file.md', true);
         testTaskFilterForTaskWithPath(filter, '/other/path/file.md', false);
@@ -32,6 +33,7 @@ describe('path', () => {
         );
 
         // Assert
+        testTaskFilterForTaskWithPath(filter, '', true);
         testTaskFilterForTaskWithPath(filter, '/some/path/file.md', false);
         testTaskFilterForTaskWithPath(filter, '/other/path/file.md', true);
     });

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -1,0 +1,19 @@
+import type { FilterOrErrorMessage } from '../../src/Query/Filter/Filter';
+import type { Task } from '../../src/Task';
+
+/**
+ * Convenience function to test a Filter on a single Task
+ *
+ * @param filter - a FilterOrErrorMessage, which should have a valid Filter.
+ * @param task - the Task to filter.
+ * @param expected true if the task should match the filter, and false otherwise.
+ */
+export function testTaskFilter(
+    filter: FilterOrErrorMessage,
+    task: Task,
+    expected: boolean,
+) {
+    expect(filter.filter).toBeDefined();
+    expect(filter.error).toBeUndefined();
+    expect(filter.filter!(task)).toEqual(expected);
+}

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -81,6 +81,10 @@ export class TaskBuilder {
         return this;
     }
 
+    /** Set the task's path on disc, including file name extension
+     *
+     * @param path Path to file, including file name extension. Use empty string to indicate 'unknown
+     */
     public path(path: string): TaskBuilder {
         this._path = path;
         return this;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor to divide up the filtering code for description, path and heading in to separate classes.

Add new classes:

- `DescriptionField`
- `HeadingField`
- `PathField`
- and `TextField`, which is an abstract base class for all the above


## Motivation and Context

This is part of addressing #664: 'refactor the Query class to be more modular'.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As with #690:

- remove duplicated code in Query class
- make it easy to add new types of filter in future
- make the code easier to understand

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Done in small refactoring steps, to guarantee behaviour unchanged.
- Created a new test file for each of the new tasks
- Where tests for these features were in Query.test.ts and easy to move, I moved those to the new test files.
- Introduced new testing helper function `testTaskFilter()`
    - this really streamlines testing of filters, as it takes a filter and a single task, and a bool to indicate whether that task matches that filter.
    - Being able to use the TaskBuilder to easily create individual tasks with specific states and then say whether they should match results in clearer tests

## Screenshots (if appropriate):

Not appropriate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/schemar/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/schemar/obsidian-tasks/blob/main/CONTRIBUTING.md)
