### PR TITLE
fix: Fix typo in error message for priority instruction.

### DIFF
--- a/src/Query/Filter/PriorityField.ts
+++ b/src/Query/Filter/PriorityField.ts
@@ -51,7 +51,7 @@ export class PriorityField extends Field {
 
             result.filter = filter;
         } else {
-            result.error = 'do not understand query filter (priority date)';
+            result.error = 'do not understand query filter (priority)';
         }
         return result;
     }

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -74,8 +74,6 @@ describe('priority error cases', () => {
             'priority is no-such-priority',
         );
         expect(filter.filter).toBeUndefined();
-        expect(filter.error).toBe(
-            'do not understand query filter (priority date)',
-        );
+        expect(filter.error).toBe('do not understand query filter (priority)');
     });
 });


### PR DESCRIPTION
## Description

A tiny change: This error message:

`'do not understand query filter (priority date)'`

Is now:

`'do not understand query filter (priority)'`

## Motivation and Context

Only noticed when writing a test for the error handling - fixed because it was easy to do so.

## How has this been tested?

By updating the existing test code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/schemar/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/schemar/obsidian-tasks/blob/main/CONTRIBUTING.md)
